### PR TITLE
Make parser specs more readable

### DIFF
--- a/test/graphql_parser_test.exs
+++ b/test/graphql_parser_test.exs
@@ -1,89 +1,38 @@
 defmodule GraphqlParserTest do
   use ExUnit.Case
 
-  def assert_parse(input, output) do
-    {:ok, tokens, _} = :graphql_lexer.string(input)
-    # IO.inspect tokens
-    {:ok, parse_result} = :graphql_parser.parse(tokens)
-    assert parse_result == output
+  def tokenize(string) do
+    {:ok, tokens, _} = :graphql_lexer.string(string)
+    tokens
   end
 
-  def assert_parse_tokens(input_tokens, output) do
-    {:ok, parse_result} = :graphql_parser.parse(input_tokens)
-    assert parse_result == output
+  def assert_parse(input_string, expected_tokens) do
+    {:ok, parse_result} = :graphql_parser.parse(tokenize(input_string))
+    assert parse_result == expected_tokens
   end
 
-  # just tokens
   test "simple selection set" do
-    assert_parse_tokens [
-      {:'{', 1},
-      {:name, 1, 'hero'},
-      {:'}', 1}
-    ], [{ ['hero'] }]
+    assert_parse '{hero}', [{ ['hero'] }]
   end
 
   test "aliased selection set" do
-    assert_parse_tokens [
-      {:'{', 1},
-      {:name, 1, 'alias'},
-      {:':', 1},
-      {:name, 1, 'hero'},
-      {:'}', 1}
-    ], [{ [{'alias', 'hero'}] }]
+    assert_parse '{alias: hero}', [{ [{'alias', 'hero'}] }]
   end
 
   test "multiple selection set" do
-    assert_parse_tokens [
-      {:'{', 1},
-      {:name, 1, 'id'},
-      {:name, 1, 'name'},
-      {:'}', 1}
-    ], [{ ['id', 'name'] }]
+    assert_parse '{id name}', [{ ['id', 'name'] }]
   end
 
   test "nested selection set" do
-    assert_parse_tokens [
-      {:'{', 1},
-      {:name, 1, 'me'},
-      {:'{', 1},
-      {:name, 1, 'name'},
-      {:'}', 1},
-      {:'}', 1}
-    ], [{ [{ 'me', {['name']} }] }]
+    assert_parse '{me {name}}', [{ [{ 'me', {['name']} }] }]
   end
 
   test "named query with nested selection set" do
-    assert_parse_tokens [
-      {:'query', 1},
-      {:name, 1, 'myName'},
-      {:'{', 1},
-      {:name, 1, 'me'},
-      {:'{', 1},
-      {:name, 1, 'name'},
-      {:'}', 1},
-      {:'}', 1}
-    ], [{ :query, 'myName', { [{ 'me', {['name']} }] } }]
+    assert_parse 'query myName {me {name}}', [{ :query, 'myName', { [{ 'me', {['name']} }] } }]
   end
 
   test "nested selection set with arguments" do
-    assert_parse_tokens [
-      {:'{', 1},
-      {:name, 1, 'user'},
-      {:'(', 1},
-      {:name, 1, 'id'},
-      {:':', 1},
-      {:int_value, 1, '4'},
-      {:')', 1},
-      {:'{', 1},
-      {:name, 1, 'name'},
-      {:'(', 1},
-      {:name, 1, 'thing'},
-      {:':', 1},
-      {:int_value, 1, 'abc'},
-      {:')', 1},
-      {:'}', 1},
-      {:'}', 1}
-    ], [{[{'user', [{'id', '4'}], {[{'name', [{'thing', 'abc'}]}]}}]}]
+    assert_parse '{user(id: 4) {name(thing: 123)}}', [{[{'user', [{'id', '4'}], {[{'name', [{'thing', '123'}]}]}}]}]
   end
 
   # strings


### PR DESCRIPTION
Testing the parser by passing strings rather than writing eye-bleeding token
literals.
