### PR TITLE
Allow reserved words as Names

### DIFF
--- a/src/graphql_lexer.erl
+++ b/src/graphql_lexer.erl
@@ -1,4 +1,4 @@
--file("/usr/local/Cellar/erlang/17.4_1/lib/erlang/lib/parsetools-2.0.12/include/leexinc.hrl", 0).
+-file("/usr/local/Cellar/erlang/17.5/lib/erlang/lib/parsetools-2.0.12/include/leexinc.hrl", 0).
 %% The source of this file is part of leex distribution, as such it
 %% has the same Copyright as the other files in the leex
 %% distribution. The Copyright is defined in the accompanying file
@@ -14,7 +14,7 @@
 %% User code. This is placed here to allow extra attributes.
 -file("src/graphql_lexer.xrl", 58).
 
--file("/usr/local/Cellar/erlang/17.4_1/lib/erlang/lib/parsetools-2.0.12/include/leexinc.hrl", 14).
+-file("/usr/local/Cellar/erlang/17.5/lib/erlang/lib/parsetools-2.0.12/include/leexinc.hrl", 14).
 
 format_error({illegal,S}) -> ["illegal characters ",io_lib:write_string(S)];
 format_error({user,S}) -> S.
@@ -1589,4 +1589,4 @@ yyaction_6(TokenChars, TokenLine) ->
 yyaction_7(TokenChars, TokenLine) ->
      { token, { name, TokenLine, TokenChars } } .
 
--file("/usr/local/Cellar/erlang/17.4_1/lib/erlang/lib/parsetools-2.0.12/include/leexinc.hrl", 282).
+-file("/usr/local/Cellar/erlang/17.5/lib/erlang/lib/parsetools-2.0.12/include/leexinc.hrl", 282).

--- a/src/graphql_parser.erl
+++ b/src/graphql_parser.erl
@@ -299,14 +299,14 @@ yeccpars2(46=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_46(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(47=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_47(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(48=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_48(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(48=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_48(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(49=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_49(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(50=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_50(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(51=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(50=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(51=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(52=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_52(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(53=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -317,28 +317,28 @@ yeccpars2(51=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(56=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(57=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_57(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(58=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(57=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(58=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_58(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(59=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_59(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(60=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_60(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(61=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(60=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(61=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_61(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(62=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_62(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(63=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_63(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(64=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_64(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(65=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_65(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(65=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_65(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(66=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(67=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(67=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(68=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_68(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(69=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -349,10 +349,10 @@ yeccpars2(67=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_71(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(72=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_72(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(73=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_73(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(74=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(73=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(74=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_74(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(75=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_75(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(76=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -363,34 +363,34 @@ yeccpars2(78=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_78(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(79=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_79(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(80=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_80(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(80=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_80(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(81=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_81(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(82=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_82(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(83=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_83(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(83=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_83(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(84=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_84(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(85=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(85=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_85(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(86=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_86(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(87=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_87(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(88=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_88(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(87=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_87(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(88=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_88(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(89=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_89(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(90=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_90(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(91=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_91(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(92=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_92(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(93=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_93(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(90=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_90(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(91=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_91(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(92=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_92(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(93=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_93(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(94=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_94(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(95=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -419,10 +419,10 @@ yeccpars2(93=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_106(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(107=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_107(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(108=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_108(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(109=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_109(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(108=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_108(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(109=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_109(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(110=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_110(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(111=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -431,182 +431,180 @@ yeccpars2(109=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_112(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(113=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_113(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(114=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_114(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(115=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_115(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(116=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_116(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(117=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(114=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_114(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(115=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_115(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(116=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(117=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_117(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(118=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_118(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(119=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_119(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(120=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(119=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(120=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_120(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(121=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_121(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(122=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_122(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(123=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_123(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(123=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(124=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(125=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(125=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_125(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(126=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_126(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(127=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_127(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(128=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_128(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(129=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_129(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(130=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_130(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(131=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_131(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(132=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(129=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_129(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(130=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_130(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(131=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(133=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(132=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(133=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(134=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(135=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_135(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(136=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_136(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(137=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_137(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(138=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(139=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_139(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(137=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(138=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_138(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(139=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_139(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(140=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_140(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(141=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_141(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(142=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_142(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(142=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_142(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(143=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_143(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(144=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_144(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(145=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_145(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(146=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_146(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(146=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_146(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(147=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_147(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(148=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(148=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_148(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(149=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_149(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(150=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_150(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(151=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(152=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_152(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(153=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(150=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(151=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_151(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(152=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(153=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_153(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(154=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_154(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(155=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_155(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(156=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_156(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(157=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_157(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(158=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(157=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(159=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_159(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(160=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_160(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(158=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_158(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(159=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_159(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(160=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_160(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(161=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_161(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(162=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_162(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(163=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(162=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(164=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_164(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(165=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_165(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(166=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_166(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(167=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%% yeccpars2(163=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_163(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(164=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_164(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(165=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_165(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(166=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(168=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_168(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(169=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_169(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(170=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_170(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(171=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%% yeccpars2(167=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_167(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(168=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_168(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(169=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_169(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(170=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(171=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(172=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_52(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_172(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(173=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_173(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(174=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_174(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(175=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_175(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(176=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_176(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(177=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_177(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(178=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(177=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(178=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_178(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(179=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_179(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(180=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_180(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(181=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_181(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(182=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_182(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(183=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_183(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(182=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_182(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(183=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_183(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(184=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_184(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(185=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_185(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(186=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_52(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_186(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(187=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_187(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(188=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(189=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_189(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(188=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_188(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(189=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_189(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(190=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_190(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(191=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_191(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(192=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_192(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(193=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(192=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(193=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_193(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(194=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_194(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(195=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_195(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(196=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_196(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(197=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_197(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(196=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_196(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(197=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_197(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(198=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_198(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(199=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_199(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(200=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(201=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_201(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_200(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -651,38 +649,33 @@ yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccpars2_5(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'TypeDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_6(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_cont_6(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_6(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_cont_6(_, _, _, _, T, _, _) ->
+yeccpars2_6(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_7(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -767,13 +760,11 @@ yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 yeccpars2_26(S, '...', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 34, Ss, Stack, T, Ts, Tzr);
-yeccpars2_26(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
 yeccpars2_26(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_27(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 115, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 114, Ss, Stack, T, Ts, Tzr);
 yeccpars2_27(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -797,26 +788,24 @@ yeccpars2_28(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(S, query, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(S, scalar, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(S, type, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_28_(Stack),
  'yeccgoto_\'Selections\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_29(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 60, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 109, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 108, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -835,9 +824,9 @@ yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %% yeccpars2_33: see yeccpars2_6
 
 yeccpars2_34(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 51, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 50, Ss, Stack, T, Ts, Tzr);
 yeccpars2_34(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_35(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_35_(Stack),
@@ -892,213 +881,177 @@ yeccpars2_47(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_48(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_48_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
-
-yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'FragmentName\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_50(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
-yeccpars2_50(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_49(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
+yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_50_(Stack),
+ NewStack = yeccpars2_49_(Stack),
  'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_51(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, extend, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, fragment, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, implements, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, input, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, interface, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, mutation, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, null, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, query, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, scalar, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, type, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_51_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+%% yeccpars2_50: see yeccpars2_6
 
-yeccpars2_52(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
-yeccpars2_52(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_51(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_52(_, _, _, _, T, _, _) ->
+yeccpars2_51(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'TypeCondition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_54_(Stack),
+yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_53_(Stack),
  'yeccgoto_\'NamedType\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_55_(Stack),
+ NewStack = yeccpars2_54_(Stack),
  'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_56(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_55(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_56(_, _, _, _, T, _, _) ->
+yeccpars2_55(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_57(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
-yeccpars2_57(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_57_(Stack),
+yeccpars2_56(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
+yeccpars2_56(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_56_(Stack),
  'yeccgoto_\'Directives\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_58: see yeccpars2_6
+%% yeccpars2_57: see yeccpars2_6
 
-yeccpars2_59(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
-yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_58(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 60, Ss, Stack, T, Ts, Tzr);
+yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
+ NewStack = yeccpars2_58_(Stack),
+ 'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_59_(Stack),
  'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_60_(Stack),
- 'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_60: see yeccpars2_6
 
-%% yeccpars2_61: see yeccpars2_6
+yeccpars2_61(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 66, Ss, Stack, T, Ts, Tzr);
+yeccpars2_61(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_62(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 67, Ss, Stack, T, Ts, Tzr);
+yeccpars2_62(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 65, Ss, Stack, T, Ts, Tzr);
 yeccpars2_62(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_63(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 66, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_64(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_63(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_64(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_64_(Stack),
+yeccpars2_63(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_63_(Stack),
  'yeccgoto_\'ArgumentList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_65(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_64(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_65_(Stack),
+ NewStack = yeccpars2_64_(Stack),
  'yeccgoto_\'ArgumentList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_66(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_66_(Stack),
+ NewStack = yeccpars2_65_(Stack),
  'yeccgoto_\'Arguments\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_67(S, '$', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_66(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
+yeccpars2_66(S, '[', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, '[', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_66(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_66(S, float_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_66(S, int_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_66(S, string_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_66(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_69_(Stack),
+ NewStack = yeccpars2_68_(Stack),
  'yeccgoto_\'Argument\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_70_(Stack),
+yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_69_(Stack),
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'EnumValue\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_71_(Stack),
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_72_(Stack),
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_73_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+%% yeccpars2_73: see yeccpars2_6
 
-%% yeccpars2_74: see yeccpars2_6
-
-yeccpars2_75(S, '$', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_74(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
+yeccpars2_74(S, '[', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, '[', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_74(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 90, Ss, Stack, T, Ts, Tzr);
+yeccpars2_74(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 91, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_74(S, float_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_74(S, int_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_74(S, string_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_74(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
-yeccpars2_75(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_74(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_75(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_75_(Stack),
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_76(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_76_(Stack),
@@ -1112,183 +1065,182 @@ yeccpars2_78(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_78_(Stack),
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_79(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_79_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+yeccpars2_79(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 83, Ss, Stack, T, Ts, Tzr);
+yeccpars2_79(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_80(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
 yeccpars2_80(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 84, Ss, Stack, T, Ts, Tzr);
-yeccpars2_80(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_81(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 88, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(_, _, _, _, T, _, _) ->
+ yeccpars1(S, 87, Ss, Stack, T, Ts, Tzr);
+yeccpars2_80(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_82(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_82(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_82_(Stack),
+yeccpars2_81(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_81_(Stack),
  'yeccgoto_\'ObjectFields\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_83(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 85, Ss, Stack, T, Ts, Tzr);
-yeccpars2_83(_, _, _, _, T, _, _) ->
+yeccpars2_82(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 84, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_84(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_83(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_84_(Stack),
+ NewStack = yeccpars2_83_(Stack),
  'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_85: see yeccpars2_67
+%% yeccpars2_84: see yeccpars2_66
 
-yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_85(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_86_(Stack),
+ NewStack = yeccpars2_85_(Stack),
  'yeccgoto_\'ObjectField\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_87(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_87_(Stack),
+ NewStack = yeccpars2_86_(Stack),
  'yeccgoto_\'ObjectFields\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_88(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_87(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_88_(Stack),
+ NewStack = yeccpars2_87_(Stack),
  'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_89(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 93, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(_, _, _, _, T, _, _) ->
+yeccpars2_88(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 92, Ss, Stack, T, Ts, Tzr);
+yeccpars2_88(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_90(S, '$', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
+yeccpars2_89(S, '[', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, '[', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, float_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
+yeccpars2_89(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, int_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
+yeccpars2_89(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
+yeccpars2_89(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, string_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_89(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
-yeccpars2_90(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_90_(Stack),
+yeccpars2_89(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
+yeccpars2_89(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_89_(Stack),
  'yeccgoto_\'Values\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_90(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_90_(Stack),
+ 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_91(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_91_(Stack),
- 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_92(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_92_(Stack),
  'yeccgoto_\'Values\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_92(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_93_(Stack),
+ NewStack = yeccpars2_92_(Stack),
  'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_93_(Stack),
+ 'yeccgoto_\'Variable\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_94(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_94_(Stack),
- 'yeccgoto_\'Variable\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_95_(Stack),
  'yeccgoto_\'Directives\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_96_(Stack),
+ NewStack = yeccpars2_95_(Stack),
  'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_97_(Stack),
+ NewStack = yeccpars2_96_(Stack),
  'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_98(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
-yeccpars2_98(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
-yeccpars2_98(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_97(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 60, Ss, Stack, T, Ts, Tzr);
+yeccpars2_97(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
+yeccpars2_97(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_98(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
+ NewStack = yeccpars2_97_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_98(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_98_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_99(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_99(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_99_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_100(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
 yeccpars2_100(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_100(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -1296,42 +1248,42 @@ yeccpars2_100(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_100_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_101(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
-yeccpars2_101(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_101(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_101_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_102(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_102(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_102_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_103(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_103(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_103_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_104(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_104_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_105_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_106(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_106(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_106_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_107(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
 yeccpars2_107(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_107(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -1339,540 +1291,521 @@ yeccpars2_107(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_107_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_108(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
-yeccpars2_108(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_108(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_108_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_109(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_109_(Stack),
  'yeccgoto_\'Alias\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_109(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_109_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_110(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_110(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_110_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_111(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_111(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_111_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_112(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_112_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_113_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_114(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_114_(Stack),
+ NewStack = yeccpars2_113_(Stack),
  'yeccgoto_\'Selections\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_115(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_114(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_115_(Stack),
+ NewStack = yeccpars2_114_(Stack),
  'yeccgoto_\'SelectionSet\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_116(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 117, Ss, Stack, T, Ts, Tzr);
-yeccpars2_116(_, _, _, _, T, _, _) ->
+yeccpars2_115(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 116, Ss, Stack, T, Ts, Tzr);
+yeccpars2_115(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_117: see yeccpars2_6
+%% yeccpars2_116: see yeccpars2_6
 
-yeccpars2_118(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_117(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_118_(Stack),
+ NewStack = yeccpars2_117_(Stack),
  'yeccgoto_\'UnionTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_119(S, '|', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 120, Ss, Stack, T, Ts, Tzr);
-yeccpars2_119(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_119_(Stack),
+yeccpars2_118(S, '|', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 119, Ss, Stack, T, Ts, Tzr);
+yeccpars2_118(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_118_(Stack),
  'yeccgoto_\'UnionMembers\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_120: see yeccpars2_6
+%% yeccpars2_119: see yeccpars2_6
 
-yeccpars2_121(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_120(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_121_(Stack),
+ NewStack = yeccpars2_120_(Stack),
  'yeccgoto_\'UnionMembers\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_122(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_121(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 123, Ss, Stack, T, Ts, Tzr);
+yeccpars2_121(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 124, Ss, Stack, T, Ts, Tzr);
+yeccpars2_121(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
 yeccpars2_122(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 125, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 157, Ss, Stack, T, Ts, Tzr);
 yeccpars2_122(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_123(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 158, Ss, Stack, T, Ts, Tzr);
-yeccpars2_123(_, _, _, _, T, _, _) ->
- yeccerror(T).
+%% yeccpars2_123: see yeccpars2_6
 
 %% yeccpars2_124: see yeccpars2_6
 
-%% yeccpars2_125: see yeccpars2_6
-
-yeccpars2_126(S, '(', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_125(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 131, Ss, Stack, T, Ts, Tzr);
+yeccpars2_125(S, ':', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 132, Ss, Stack, T, Ts, Tzr);
-yeccpars2_126(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 133, Ss, Stack, T, Ts, Tzr);
+yeccpars2_125(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_126(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 129, Ss, Stack, T, Ts, Tzr);
 yeccpars2_126(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_127(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 130, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_128(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_128(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_128_(Stack),
+yeccpars2_127(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_127_(Stack),
  'yeccgoto_\'FieldDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_129(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_128(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_129_(Stack),
+ NewStack = yeccpars2_128_(Stack),
  'yeccgoto_\'FieldDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_130(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_130_(Stack),
+ NewStack = yeccpars2_129_(Stack),
  'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_131(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 153, Ss, Stack, T, Ts, Tzr);
-yeccpars2_131(_, _, _, _, T, _, _) ->
+yeccpars2_130(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 152, Ss, Stack, T, Ts, Tzr);
+yeccpars2_130(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_132: see yeccpars2_6
+%% yeccpars2_131: see yeccpars2_6
 
-yeccpars2_133(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 138, Ss, Stack, T, Ts, Tzr);
-yeccpars2_133(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_132(S, '[', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 137, Ss, Stack, T, Ts, Tzr);
+yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_133(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_134_(Stack),
+ NewStack = yeccpars2_133_(Stack),
  'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_135(S, '!', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 141, Ss, Stack, T, Ts, Tzr);
 yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_136(S, '!', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 142, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 140, Ss, Stack, T, Ts, Tzr);
 yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_137(S, '!', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 141, Ss, Stack, T, Ts, Tzr);
-yeccpars2_137(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+%% yeccpars2_137: see yeccpars2_132
 
-%% yeccpars2_138: see yeccpars2_133
-
-yeccpars2_139(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 140, Ss, Stack, T, Ts, Tzr);
-yeccpars2_139(_, _, _, _, T, _, _) ->
+yeccpars2_138(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 139, Ss, Stack, T, Ts, Tzr);
+yeccpars2_138(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_140(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_139(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_140_(Stack),
+ NewStack = yeccpars2_139_(Stack),
  'yeccgoto_\'ListType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_140(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_140_(Stack),
+ 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_141(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_141_(Stack),
  'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_142(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_142_(Stack),
- 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_142(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 147, Ss, Stack, T, Ts, Tzr);
+yeccpars2_142(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_143(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 148, Ss, Stack, T, Ts, Tzr);
+yeccpars2_143(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 146, Ss, Stack, T, Ts, Tzr);
 yeccpars2_143(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_144(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 147, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_145(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_144(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_145(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_145_(Stack),
+yeccpars2_144(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_144_(Stack),
  'yeccgoto_\'InputValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_146(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_145(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_146_(Stack),
+ NewStack = yeccpars2_145_(Stack),
  'yeccgoto_\'InputValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_147(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_147_(Stack),
+ NewStack = yeccpars2_146_(Stack),
  'yeccgoto_\'ArgumentsDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_148: see yeccpars2_133
+%% yeccpars2_147: see yeccpars2_132
 
-yeccpars2_149(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 151, Ss, Stack, T, Ts, Tzr);
-yeccpars2_149(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_148(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 150, Ss, Stack, T, Ts, Tzr);
+yeccpars2_148(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
+ NewStack = yeccpars2_148_(Stack),
+ 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_149(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_149_(Stack),
  'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_150(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_150_(Stack),
- 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_150: see yeccpars2_66
 
-%% yeccpars2_151: see yeccpars2_67
-
-yeccpars2_152(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_151(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_152_(Stack),
+ NewStack = yeccpars2_151_(Stack),
  'yeccgoto_\'DefaultValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_153: see yeccpars2_133
+%% yeccpars2_152: see yeccpars2_132
 
-yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_153(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_154_(Stack),
+ NewStack = yeccpars2_153_(Stack),
  'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_155(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_155_(Stack),
+ NewStack = yeccpars2_154_(Stack),
  'yeccgoto_\'ImplementsInterfaces\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_156(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_155(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_156(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_156_(Stack),
+yeccpars2_155(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_155_(Stack),
  'yeccgoto_\'NamedTypeList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_157(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_156(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_157_(Stack),
+ NewStack = yeccpars2_156_(Stack),
  'yeccgoto_\'NamedTypeList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_158: see yeccpars2_6
+%% yeccpars2_157: see yeccpars2_6
 
-yeccpars2_159(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 160, Ss, Stack, T, Ts, Tzr);
-yeccpars2_159(_, _, _, _, T, _, _) ->
+yeccpars2_158(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 159, Ss, Stack, T, Ts, Tzr);
+yeccpars2_158(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_160(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_159(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_160_(Stack),
+ NewStack = yeccpars2_159_(Stack),
  'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_161(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_160(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_161_(Stack),
+ NewStack = yeccpars2_160_(Stack),
  'yeccgoto_\'ScalarTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_162(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 163, Ss, Stack, T, Ts, Tzr);
-yeccpars2_162(_, _, _, _, T, _, _) ->
+yeccpars2_161(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 162, Ss, Stack, T, Ts, Tzr);
+yeccpars2_161(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_163: see yeccpars2_6
+%% yeccpars2_162: see yeccpars2_6
 
-yeccpars2_164(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 165, Ss, Stack, T, Ts, Tzr);
-yeccpars2_164(_, _, _, _, T, _, _) ->
+yeccpars2_163(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 164, Ss, Stack, T, Ts, Tzr);
+yeccpars2_163(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_165(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_164(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_165_(Stack),
+ NewStack = yeccpars2_164_(Stack),
  'yeccgoto_\'InterfaceTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_166(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 167, Ss, Stack, T, Ts, Tzr);
-yeccpars2_166(_, _, _, _, T, _, _) ->
+yeccpars2_165(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 166, Ss, Stack, T, Ts, Tzr);
+yeccpars2_165(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_167: see yeccpars2_6
+%% yeccpars2_166: see yeccpars2_6
 
-yeccpars2_168(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 169, Ss, Stack, T, Ts, Tzr);
-yeccpars2_168(_, _, _, _, T, _, _) ->
+yeccpars2_167(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 168, Ss, Stack, T, Ts, Tzr);
+yeccpars2_167(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_169(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_168(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_169_(Stack),
+ NewStack = yeccpars2_168_(Stack),
  'yeccgoto_\'InputObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_170(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 171, Ss, Stack, T, Ts, Tzr);
-yeccpars2_170(_, _, _, _, T, _, _) ->
+yeccpars2_169(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 170, Ss, Stack, T, Ts, Tzr);
+yeccpars2_169(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_171: see yeccpars2_6
+%% yeccpars2_170: see yeccpars2_6
 
-%% yeccpars2_172: see yeccpars2_52
+%% yeccpars2_171: see yeccpars2_51
 
-yeccpars2_173(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_172(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_173_(Stack),
+ NewStack = yeccpars2_172_(Stack),
  'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_174: see yeccpars2_56
+%% yeccpars2_173: see yeccpars2_55
+
+yeccpars2_174(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_174_(Stack),
+ 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_175(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_175_(Stack),
- 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_176(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_176_(Stack),
+ NewStack = yeccpars2_175_(Stack),
  'yeccgoto_\'TypeExtensionDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_177(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 178, Ss, Stack, T, Ts, Tzr);
-yeccpars2_177(_, _, _, _, T, _, _) ->
+yeccpars2_176(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 177, Ss, Stack, T, Ts, Tzr);
+yeccpars2_176(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_178: see yeccpars2_6
+%% yeccpars2_177: see yeccpars2_6
 
-yeccpars2_179(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 183, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(_, _, _, _, T, _, _) ->
+yeccpars2_178(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 182, Ss, Stack, T, Ts, Tzr);
+yeccpars2_178(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_180(S, enum, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, type, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_179(S, union, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_180_(Stack),
+yeccpars2_179(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_179_(Stack),
  'yeccgoto_\'EnumValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'EnumValueDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_182_(Stack),
+ NewStack = yeccpars2_181_(Stack),
  'yeccgoto_\'EnumValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_183_(Stack),
+ NewStack = yeccpars2_182_(Stack),
  'yeccgoto_\'EnumTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_184(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_184_(Stack),
+ NewStack = yeccpars2_183_(Stack),
  'yeccgoto_\'Definitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_185(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 189, Ss, Stack, T, Ts, Tzr);
-yeccpars2_185(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
-yeccpars2_185(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_184(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 188, Ss, Stack, T, Ts, Tzr);
+yeccpars2_184(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
+yeccpars2_184(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_185(_, _, _, _, T, _, _) ->
+yeccpars2_184(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_186: see yeccpars2_52
+%% yeccpars2_185: see yeccpars2_51
 
-yeccpars2_187(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_186(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_187_(Stack),
+ NewStack = yeccpars2_186_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_188: see yeccpars2_56
+%% yeccpars2_187: see yeccpars2_55
 
-yeccpars2_189(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
+yeccpars2_188(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
+yeccpars2_188(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_189(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 196, Ss, Stack, T, Ts, Tzr);
 yeccpars2_189(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_190(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 197, Ss, Stack, T, Ts, Tzr);
-yeccpars2_190(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_191(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
-yeccpars2_191(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_191_(Stack),
+yeccpars2_190(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
+yeccpars2_190(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_190_(Stack),
  'yeccgoto_\'VariableDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_192(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 193, Ss, Stack, T, Ts, Tzr);
-yeccpars2_192(_, _, _, _, T, _, _) ->
+yeccpars2_191(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 192, Ss, Stack, T, Ts, Tzr);
+yeccpars2_191(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_193: see yeccpars2_133
+%% yeccpars2_192: see yeccpars2_132
 
-yeccpars2_194(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 151, Ss, Stack, T, Ts, Tzr);
-yeccpars2_194(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_193(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 150, Ss, Stack, T, Ts, Tzr);
+yeccpars2_193(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
+ NewStack = yeccpars2_193_(Stack),
+ 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_194(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_194_(Stack),
  'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_195(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_195_(Stack),
- 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_196(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_196_(Stack),
+ NewStack = yeccpars2_195_(Stack),
  'yeccgoto_\'VariableDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_197(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_196(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_197_(Stack),
+ NewStack = yeccpars2_196_(Stack),
  'yeccgoto_\'VariableDefinitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_197(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_197_(Stack),
+ 'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_198(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_198_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_199(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_199_(Stack),
- 'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_199: see yeccpars2_55
 
-%% yeccpars2_200: see yeccpars2_56
-
-yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_201_(Stack),
+ NewStack = yeccpars2_200_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 'yeccgoto_\'Alias\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -1880,30 +1813,30 @@ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'Alias\''(28, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(33, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Argument\''(61, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_64(64, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Argument\''(64, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_64(64, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'ArgumentList\''(61, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'Argument\''(60, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_63(63, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ArgumentList\''(64=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_65(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Argument\''(63, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_63(63, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'ArgumentList\''(60, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_62(62, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ArgumentList\''(63=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_64(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Arguments\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_108(108, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Arguments\''(59=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Arguments\''(98, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_101(101, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_107(107, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Arguments\''(58=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Arguments\''(97, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_100(100, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ArgumentsDefinition\''(126, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_131(131, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ArgumentsDefinition\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_130(130, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'DefaultValue\''(149=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_150(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'DefaultValue\''(194=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_195(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'DefaultValue\''(148=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_149(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'DefaultValue\''(193=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_194(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Definition\''(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_15(15, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1913,49 +1846,49 @@ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'Definitions\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Definitions\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_184(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Directive\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(50, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(52, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(57, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(98, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(101, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(108, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(172, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(49, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(56, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(97, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(100, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(107, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(171, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(184, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Directive\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(186, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Directives\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_107(107, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(50=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(52, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(57=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(98, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_100(100, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(101, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_103(103, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(108, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_111(111, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(172, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(174, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_106(106, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(49=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(55, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(56=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_94(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(97, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_99(99, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(100, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_102(102, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(107, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_110(110, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(171, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(173, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(184, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(187, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Directives\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(188, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(186, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(200, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_55(199, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Document\''(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_13(13, Cat, Ss, Stack, T, Ts, Tzr).
@@ -1965,53 +1898,53 @@ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'EnumTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_12(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValue\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(178=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(180=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'EnumValue\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(177=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(179=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValueDefinition\''(178, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_180(180, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValueDefinition\''(180, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_180(180, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'EnumValueDefinitionList\''(178, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'EnumValueDefinition\''(177, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_179(179, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValueDefinitionList\''(180=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'EnumValueDefinition\''(179, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_179(179, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'EnumValueDefinitionList\''(177, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_178(178, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValueDefinitionList\''(179=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Field\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Field\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'FieldDefinition\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(128, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(158, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(163, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'FieldDefinitionList\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'FieldDefinition\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(128=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_129(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(158, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_159(159, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(163, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_164(164, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'FieldDefinition\''(127, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(157, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(162, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'FieldDefinitionList\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(127=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_128(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(157, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_158(158, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(162, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_163(163, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -2019,17 +1952,17 @@ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentName\''(18, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_170(170, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_169(169, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'FragmentName\''(34, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_50(50, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_49(49, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentSpread\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'FragmentSpread\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ImplementsInterfaces\''(122, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ImplementsInterfaces\''(121, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_122(122, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'InlineFragment\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_30(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -2041,200 +1974,200 @@ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'InputObjectTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'InputValueDefinition\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_145(145, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinition\''(145, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_145(145, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinition\''(167, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_145(145, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'InputValueDefinitionList\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'InputValueDefinition\''(131, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinitionList\''(145=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_146(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinitionList\''(167, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_168(168, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'InputValueDefinition\''(144, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinition\''(166, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'InputValueDefinitionList\''(131, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinitionList\''(144=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_145(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinitionList\''(166, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_167(167, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'InterfaceTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'InterfaceTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ListType\''(133, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(138, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(148, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(153, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(193, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ListType\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(137, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(147, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(152, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ListValue\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ListValue\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Name\''(6, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_185(185, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_184(184, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(16, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_177(177, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_176(176, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(18=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_48(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(19, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_166(166, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_165(165, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(20, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_162(162, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_161(161, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(23=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_161(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_160(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(24, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_122(122, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_121(121, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(25, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_116(116, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_115(115, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_29(29, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(28, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_29(29, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(33, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_98(98, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_97(97, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(58, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_59(59, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(61, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_62(62, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(64, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_62(62, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_48(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(50=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(57, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(60, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_61(61, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(63, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_61(61, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(73=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_94(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(80, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_83(83, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(82, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_83(83, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(117=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(120=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(124=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(128, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(133=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(145, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(148=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(153=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(156=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(158, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(163, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(167, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(171=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(178=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(180=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(193=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'NamedType\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(117, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_119(119, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(120, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_119(119, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_156(156, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(133, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(138, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(148, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(153, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(156, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_156(156, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(171=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(193, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'NamedTypeList\''(124=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_155(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedTypeList\''(156=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_157(_S, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'NonNullType\''(133=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(148=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(153=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(193=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'ObjectField\''(80, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(79, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectField\''(82, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Name\''(81, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(116=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(119=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(123=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(127, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(131, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_142(142, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(132=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(137=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(144, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_142(142, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(147=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(155=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(157, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(162, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(166, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_142(142, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(170=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(177=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(179=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(192=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectFields\''(80, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'NamedType\''(50=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(116, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_118(118, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(119, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_118(118, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(123, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_155(155, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(137, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(147, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(152, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(155, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_155(155, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(170=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'NamedTypeList\''(123=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedTypeList\''(155=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_156(_S, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'NonNullType\''(132=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(137=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(147=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(192=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'ObjectField\''(79, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_81(81, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectFields\''(82=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_87(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ObjectField\''(81, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_81(81, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'ObjectFields\''(79, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_80(80, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectFields\''(81=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'ObjectTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'ObjectTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'ObjectTypeDefinition\''(17=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_176(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_175(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectValue\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ObjectValue\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'OperationDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_7(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -2261,58 +2194,58 @@ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'SelectionSet\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(29=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_106(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(52=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(56=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(98=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_99(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(100=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(101=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_102(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(103=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'SelectionSet\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(55=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(97=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_98(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(99=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_104(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(107=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(108=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_110(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(111=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'SelectionSet\''(100=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_101(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(102=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_103(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(106=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_112(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(172=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_173(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(174=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_175(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(107=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_109(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(110=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_111(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(171=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_172(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(173=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_174(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(184=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_186(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(185=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_187(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(186=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_199(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(188=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_198(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(200=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'SelectionSet\''(187=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_197(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(199=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Selections\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_27(27, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Selections\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_114(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Type\''(133=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(138, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_139(139, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(148, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_149(149, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(153=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(193, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_194(194, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Type\''(132=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_133(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(137, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_138(138, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(147, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_148(148, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_153(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_193(193, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'TypeCondition\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_52(52, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'TypeCondition\''(171, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_52(172, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'TypeCondition\''(50, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_51(51, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'TypeCondition\''(170, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_51(171, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'TypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -2324,59 +2257,59 @@ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'TypeExtensionDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_2(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'UnionMembers\''(117=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_118(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'UnionMembers\''(120=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_121(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'UnionMembers\''(116=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_117(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'UnionMembers\''(119=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_120(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'UnionTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'UnionTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Value\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(75, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_90(90, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(90, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_90(90, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_152(_S, Cat, Ss, Stack, T, Ts, Tzr).
-
-'yeccgoto_\'Values\''(75, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'Value\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(74, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_89(89, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Values\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_92(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Value\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_85(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(89, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_89(89, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_151(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Variable\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(189, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_192(192, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(191, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_192(192, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Values\''(74, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_88(88, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Values\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_91(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinition\''(189, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'Variable\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(188, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_191(191, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'VariableDefinition\''(191, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'Variable\''(190, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_191(191, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinitionList\''(189, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'VariableDefinition\''(188, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_190(190, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'VariableDefinitionList\''(191=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_196(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'VariableDefinition\''(190, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_190(190, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinitions\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_52(186, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'VariableDefinitionList\''(188, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_189(189, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'VariableDefinitionList\''(190=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_195(_S, Cat, Ss, Stack, T, Ts, Tzr).
+
+'yeccgoto_\'VariableDefinitions\''(184, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_51(185, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_4_/1}).
 -file("src/graphql_parser.yrl", 33).
@@ -2507,7 +2440,7 @@ yeccpars2_43_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_44_/1}).
--file("src/graphql_parser.yrl", 111).
+-file("src/graphql_parser.yrl", 108).
 yeccpars2_44_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2515,7 +2448,7 @@ yeccpars2_44_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_45_/1}).
--file("src/graphql_parser.yrl", 108).
+-file("src/graphql_parser.yrl", 116).
 yeccpars2_45_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2523,7 +2456,7 @@ yeccpars2_45_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_46_/1}).
--file("src/graphql_parser.yrl", 116).
+-file("src/graphql_parser.yrl", 112).
 yeccpars2_46_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2531,728 +2464,712 @@ yeccpars2_46_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_47_/1}).
--file("src/graphql_parser.yrl", 112).
+-file("src/graphql_parser.yrl", 115).
 yeccpars2_47_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    extract_keyword ( __1 )
   end | __Stack].
 
--compile({inline,yeccpars2_48_/1}).
--file("src/graphql_parser.yrl", 115).
-yeccpars2_48_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   extract_keyword ( __1 )
-  end | __Stack].
-
--compile({inline,yeccpars2_50_/1}).
+-compile({inline,yeccpars2_49_/1}).
 -file("src/graphql_parser.yrl", 70).
-yeccpars2_50_(__Stack0) ->
+yeccpars2_49_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentSpread' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_51_/1}).
--file("src/graphql_parser.yrl", 111).
-yeccpars2_51_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   extract_keyword ( __1 )
-  end | __Stack].
-
--compile({inline,yeccpars2_54_/1}).
+-compile({inline,yeccpars2_53_/1}).
 -file("src/graphql_parser.yrl", 56).
-yeccpars2_54_(__Stack0) ->
+yeccpars2_53_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'NamedType' , [ { name , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_55_/1}).
+-compile({inline,yeccpars2_54_/1}).
 -file("src/graphql_parser.yrl", 73).
-yeccpars2_55_(__Stack0) ->
+yeccpars2_54_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InlineFragment' , [ { typeCondition , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_57_/1}).
+-compile({inline,yeccpars2_56_/1}).
 -file("src/graphql_parser.yrl", 102).
-yeccpars2_57_(__Stack0) ->
+yeccpars2_56_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_59_/1}).
+-compile({inline,yeccpars2_58_/1}).
 -file("src/graphql_parser.yrl", 104).
-yeccpars2_59_(__Stack0) ->
+yeccpars2_58_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Directive' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_60_/1}).
+-compile({inline,yeccpars2_59_/1}).
 -file("src/graphql_parser.yrl", 105).
-yeccpars2_60_(__Stack0) ->
+yeccpars2_59_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Directive' , [ { name , __2 } , { arguments , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_64_/1}).
+-compile({inline,yeccpars2_63_/1}).
 -file("src/graphql_parser.yrl", 98).
-yeccpars2_64_(__Stack0) ->
+yeccpars2_63_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_65_/1}).
+-compile({inline,yeccpars2_64_/1}).
 -file("src/graphql_parser.yrl", 99).
-yeccpars2_65_(__Stack0) ->
+yeccpars2_64_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_66_/1}).
+-compile({inline,yeccpars2_65_/1}).
 -file("src/graphql_parser.yrl", 97).
-yeccpars2_66_(__Stack0) ->
+yeccpars2_65_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_69_/1}).
+-compile({inline,yeccpars2_68_/1}).
 -file("src/graphql_parser.yrl", 100).
-yeccpars2_69_(__Stack0) ->
+yeccpars2_68_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Argument' , [ { name , __1 } , { value , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_70_/1}).
+-compile({inline,yeccpars2_69_/1}).
 -file("src/graphql_parser.yrl", 129).
-yeccpars2_70_(__Stack0) ->
+yeccpars2_69_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectValue' , [ { fields , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_72_/1}).
+-compile({inline,yeccpars2_71_/1}).
 -file("src/graphql_parser.yrl", 128).
-yeccpars2_72_(__Stack0) ->
+yeccpars2_71_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ListValue' , [ { values , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_73_/1}).
+-compile({inline,yeccpars2_72_/1}).
 -file("src/graphql_parser.yrl", 127).
-yeccpars2_73_(__Stack0) ->
+yeccpars2_72_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'EnumValue' , [ { value , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_76_/1}).
+-compile({inline,yeccpars2_75_/1}).
 -file("src/graphql_parser.yrl", 126).
-yeccpars2_76_(__Stack0) ->
+yeccpars2_75_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'BooleanValue' , [ { value , extract_boolean ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_77_/1}).
+-compile({inline,yeccpars2_76_/1}).
 -file("src/graphql_parser.yrl", 124).
-yeccpars2_77_(__Stack0) ->
+yeccpars2_76_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FloatValue' , [ { value , extract_float ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_78_/1}).
+-compile({inline,yeccpars2_77_/1}).
 -file("src/graphql_parser.yrl", 123).
-yeccpars2_78_(__Stack0) ->
+yeccpars2_77_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'IntValue' , [ { value , extract_integer ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_79_/1}).
+-compile({inline,yeccpars2_78_/1}).
 -file("src/graphql_parser.yrl", 125).
-yeccpars2_79_(__Stack0) ->
+yeccpars2_78_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'StringValue' , [ { value , extract_token ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_82_/1}).
+-compile({inline,yeccpars2_81_/1}).
 -file("src/graphql_parser.yrl", 140).
-yeccpars2_82_(__Stack0) ->
+yeccpars2_81_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_84_/1}).
+-compile({inline,yeccpars2_83_/1}).
 -file("src/graphql_parser.yrl", 138).
-yeccpars2_84_(__Stack0) ->
+yeccpars2_83_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ ]
   end | __Stack].
 
--compile({inline,yeccpars2_86_/1}).
+-compile({inline,yeccpars2_85_/1}).
 -file("src/graphql_parser.yrl", 142).
-yeccpars2_86_(__Stack0) ->
+yeccpars2_85_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectField' , [ { name , __1 } , { value , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_87_/1}).
+-compile({inline,yeccpars2_86_/1}).
 -file("src/graphql_parser.yrl", 141).
-yeccpars2_87_(__Stack0) ->
+yeccpars2_86_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_88_/1}).
+-compile({inline,yeccpars2_87_/1}).
 -file("src/graphql_parser.yrl", 139).
-yeccpars2_88_(__Stack0) ->
+yeccpars2_87_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_90_/1}).
+-compile({inline,yeccpars2_89_/1}).
 -file("src/graphql_parser.yrl", 135).
-yeccpars2_90_(__Stack0) ->
+yeccpars2_89_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_91_/1}).
+-compile({inline,yeccpars2_90_/1}).
 -file("src/graphql_parser.yrl", 133).
-yeccpars2_91_(__Stack0) ->
+yeccpars2_90_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ ]
   end | __Stack].
 
--compile({inline,yeccpars2_92_/1}).
+-compile({inline,yeccpars2_91_/1}).
 -file("src/graphql_parser.yrl", 136).
-yeccpars2_92_(__Stack0) ->
+yeccpars2_91_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_93_/1}).
+-compile({inline,yeccpars2_92_/1}).
 -file("src/graphql_parser.yrl", 134).
-yeccpars2_93_(__Stack0) ->
+yeccpars2_92_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_94_/1}).
+-compile({inline,yeccpars2_93_/1}).
 -file("src/graphql_parser.yrl", 49).
-yeccpars2_94_(__Stack0) ->
+yeccpars2_93_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Variable' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_95_/1}).
+-compile({inline,yeccpars2_94_/1}).
 -file("src/graphql_parser.yrl", 103).
-yeccpars2_95_(__Stack0) ->
+yeccpars2_94_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_96_/1}).
+-compile({inline,yeccpars2_95_/1}).
 -file("src/graphql_parser.yrl", 74).
-yeccpars2_96_(__Stack0) ->
+yeccpars2_95_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InlineFragment' , [ { typeCondition , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_97_/1}).
+-compile({inline,yeccpars2_96_/1}).
 -file("src/graphql_parser.yrl", 71).
-yeccpars2_97_(__Stack0) ->
+yeccpars2_96_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentSpread' , [ { name , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_98_/1}).
+-compile({inline,yeccpars2_97_/1}).
 -file("src/graphql_parser.yrl", 86).
-yeccpars2_98_(__Stack0) ->
+yeccpars2_97_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_99_/1}).
+-compile({inline,yeccpars2_98_/1}).
 -file("src/graphql_parser.yrl", 88).
-yeccpars2_99_(__Stack0) ->
+yeccpars2_98_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_100_/1}).
+-compile({inline,yeccpars2_99_/1}).
 -file("src/graphql_parser.yrl", 90).
-yeccpars2_100_(__Stack0) ->
+yeccpars2_99_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_101_/1}).
+-compile({inline,yeccpars2_100_/1}).
 -file("src/graphql_parser.yrl", 87).
-yeccpars2_101_(__Stack0) ->
+yeccpars2_100_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_102_/1}).
+-compile({inline,yeccpars2_101_/1}).
 -file("src/graphql_parser.yrl", 89).
-yeccpars2_102_(__Stack0) ->
+yeccpars2_101_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_103_/1}).
+-compile({inline,yeccpars2_102_/1}).
 -file("src/graphql_parser.yrl", 91).
-yeccpars2_103_(__Stack0) ->
+yeccpars2_102_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { directives , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_104_/1}).
+-compile({inline,yeccpars2_103_/1}).
 -file("src/graphql_parser.yrl", 93).
-yeccpars2_104_(__Stack0) ->
+yeccpars2_103_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_105_/1}).
+-compile({inline,yeccpars2_104_/1}).
 -file("src/graphql_parser.yrl", 92).
-yeccpars2_105_(__Stack0) ->
+yeccpars2_104_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_106_/1}).
+-compile({inline,yeccpars2_105_/1}).
 -file("src/graphql_parser.yrl", 81).
-yeccpars2_106_(__Stack0) ->
+yeccpars2_105_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { selectionSet , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_107_/1}).
+-compile({inline,yeccpars2_106_/1}).
 -file("src/graphql_parser.yrl", 80).
-yeccpars2_107_(__Stack0) ->
+yeccpars2_106_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { directives , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_108_/1}).
+-compile({inline,yeccpars2_107_/1}).
 -file("src/graphql_parser.yrl", 79).
-yeccpars2_108_(__Stack0) ->
+yeccpars2_107_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_109_/1}).
+-compile({inline,yeccpars2_108_/1}).
 -file("src/graphql_parser.yrl", 95).
-yeccpars2_109_(__Stack0) ->
+yeccpars2_108_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    __1
   end | __Stack].
 
--compile({inline,yeccpars2_110_/1}).
+-compile({inline,yeccpars2_109_/1}).
 -file("src/graphql_parser.yrl", 83).
-yeccpars2_110_(__Stack0) ->
+yeccpars2_109_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_111_/1}).
+-compile({inline,yeccpars2_110_/1}).
 -file("src/graphql_parser.yrl", 84).
-yeccpars2_111_(__Stack0) ->
+yeccpars2_110_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_112_/1}).
+-compile({inline,yeccpars2_111_/1}).
 -file("src/graphql_parser.yrl", 85).
-yeccpars2_112_(__Stack0) ->
+yeccpars2_111_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_113_/1}).
+-compile({inline,yeccpars2_112_/1}).
 -file("src/graphql_parser.yrl", 82).
-yeccpars2_113_(__Stack0) ->
+yeccpars2_112_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { directives , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_114_/1}).
+-compile({inline,yeccpars2_113_/1}).
 -file("src/graphql_parser.yrl", 64).
-yeccpars2_114_(__Stack0) ->
+yeccpars2_113_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_115_/1}).
+-compile({inline,yeccpars2_114_/1}).
 -file("src/graphql_parser.yrl", 61).
-yeccpars2_115_(__Stack0) ->
+yeccpars2_114_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'SelectionSet' , { selections , __2 } )
   end | __Stack].
 
--compile({inline,yeccpars2_118_/1}).
+-compile({inline,yeccpars2_117_/1}).
 -file("src/graphql_parser.yrl", 179).
-yeccpars2_118_(__Stack0) ->
+yeccpars2_117_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'UnionTypeDefinition' , [ { name , __2 } , { types , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_119_/1}).
+-compile({inline,yeccpars2_118_/1}).
 -file("src/graphql_parser.yrl", 181).
-yeccpars2_119_(__Stack0) ->
+yeccpars2_118_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_121_/1}).
+-compile({inline,yeccpars2_120_/1}).
 -file("src/graphql_parser.yrl", 182).
-yeccpars2_121_(__Stack0) ->
+yeccpars2_120_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __3 ]
   end | __Stack].
 
--compile({inline,yeccpars2_128_/1}).
+-compile({inline,yeccpars2_127_/1}).
 -file("src/graphql_parser.yrl", 162).
-yeccpars2_128_(__Stack0) ->
+yeccpars2_127_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_129_/1}).
+-compile({inline,yeccpars2_128_/1}).
 -file("src/graphql_parser.yrl", 163).
-yeccpars2_129_(__Stack0) ->
+yeccpars2_128_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_130_/1}).
+-compile({inline,yeccpars2_129_/1}).
 -file("src/graphql_parser.yrl", 153).
-yeccpars2_130_(__Stack0) ->
+yeccpars2_129_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_134_/1}).
+-compile({inline,yeccpars2_133_/1}).
 -file("src/graphql_parser.yrl", 164).
-yeccpars2_134_(__Stack0) ->
+yeccpars2_133_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { type , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_140_/1}).
+-compile({inline,yeccpars2_139_/1}).
 -file("src/graphql_parser.yrl", 57).
-yeccpars2_140_(__Stack0) ->
+yeccpars2_139_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ListType' , [ { type , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_141_/1}).
+-compile({inline,yeccpars2_140_/1}).
 -file("src/graphql_parser.yrl", 59).
+yeccpars2_140_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_141_/1}).
+-file("src/graphql_parser.yrl", 58).
 yeccpars2_141_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_142_/1}).
--file("src/graphql_parser.yrl", 58).
-yeccpars2_142_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_145_/1}).
+-compile({inline,yeccpars2_144_/1}).
 -file("src/graphql_parser.yrl", 169).
-yeccpars2_145_(__Stack0) ->
+yeccpars2_144_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_146_/1}).
+-compile({inline,yeccpars2_145_/1}).
 -file("src/graphql_parser.yrl", 170).
-yeccpars2_146_(__Stack0) ->
+yeccpars2_145_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_147_/1}).
+-compile({inline,yeccpars2_146_/1}).
 -file("src/graphql_parser.yrl", 167).
-yeccpars2_147_(__Stack0) ->
+yeccpars2_146_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_149_/1}).
+-compile({inline,yeccpars2_148_/1}).
 -file("src/graphql_parser.yrl", 172).
-yeccpars2_149_(__Stack0) ->
+yeccpars2_148_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_150_/1}).
+-compile({inline,yeccpars2_149_/1}).
 -file("src/graphql_parser.yrl", 173).
-yeccpars2_150_(__Stack0) ->
+yeccpars2_149_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } , { defaultValue , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_152_/1}).
+-compile({inline,yeccpars2_151_/1}).
 -file("src/graphql_parser.yrl", 51).
-yeccpars2_152_(__Stack0) ->
+yeccpars2_151_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_154_/1}).
+-compile({inline,yeccpars2_153_/1}).
 -file("src/graphql_parser.yrl", 165).
-yeccpars2_154_(__Stack0) ->
+yeccpars2_153_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { arguments , __2 } , { type , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_155_/1}).
+-compile({inline,yeccpars2_154_/1}).
 -file("src/graphql_parser.yrl", 157).
-yeccpars2_155_(__Stack0) ->
+yeccpars2_154_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_156_/1}).
+-compile({inline,yeccpars2_155_/1}).
 -file("src/graphql_parser.yrl", 159).
-yeccpars2_156_(__Stack0) ->
+yeccpars2_155_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_157_/1}).
+-compile({inline,yeccpars2_156_/1}).
 -file("src/graphql_parser.yrl", 160).
-yeccpars2_157_(__Stack0) ->
+yeccpars2_156_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_160_/1}).
+-compile({inline,yeccpars2_159_/1}).
 -file("src/graphql_parser.yrl", 155).
-yeccpars2_160_(__Stack0) ->
+yeccpars2_159_(__Stack0) ->
  [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectTypeDefinition' , [ { name , __2 } , { interfaces , __3 } , { fields , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_161_/1}).
+-compile({inline,yeccpars2_160_/1}).
 -file("src/graphql_parser.yrl", 184).
-yeccpars2_161_(__Stack0) ->
+yeccpars2_160_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ScalarTypeDefinition' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_165_/1}).
+-compile({inline,yeccpars2_164_/1}).
 -file("src/graphql_parser.yrl", 176).
-yeccpars2_165_(__Stack0) ->
+yeccpars2_164_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InterfaceTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_169_/1}).
+-compile({inline,yeccpars2_168_/1}).
 -file("src/graphql_parser.yrl", 195).
-yeccpars2_169_(__Stack0) ->
+yeccpars2_168_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InputObjectTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_173_/1}).
+-compile({inline,yeccpars2_172_/1}).
 -file("src/graphql_parser.yrl", 39).
-yeccpars2_173_(__Stack0) ->
+yeccpars2_172_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_175_/1}).
+-compile({inline,yeccpars2_174_/1}).
 -file("src/graphql_parser.yrl", 40).
-yeccpars2_175_(__Stack0) ->
+yeccpars2_174_(__Stack0) ->
  [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { directives , __5 } , { selectionSet , __6 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_176_/1}).
+-compile({inline,yeccpars2_175_/1}).
 -file("src/graphql_parser.yrl", 198).
-yeccpars2_176_(__Stack0) ->
+yeccpars2_175_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'TypeExtensionDefinition' , [ { definition , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_180_/1}).
+-compile({inline,yeccpars2_179_/1}).
 -file("src/graphql_parser.yrl", 189).
-yeccpars2_180_(__Stack0) ->
+yeccpars2_179_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_182_/1}).
+-compile({inline,yeccpars2_181_/1}).
 -file("src/graphql_parser.yrl", 190).
-yeccpars2_182_(__Stack0) ->
+yeccpars2_181_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_183_/1}).
+-compile({inline,yeccpars2_182_/1}).
 -file("src/graphql_parser.yrl", 187).
-yeccpars2_183_(__Stack0) ->
+yeccpars2_182_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'EnumTypeDefinition' , [ { name , __2 } , { values , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_184_/1}).
+-compile({inline,yeccpars2_183_/1}).
 -file("src/graphql_parser.yrl", 24).
-yeccpars2_184_(__Stack0) ->
+yeccpars2_183_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_187_/1}).
+-compile({inline,yeccpars2_186_/1}).
 -file("src/graphql_parser.yrl", 34).
-yeccpars2_187_(__Stack0) ->
+yeccpars2_186_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_191_/1}).
+-compile({inline,yeccpars2_190_/1}).
 -file("src/graphql_parser.yrl", 45).
-yeccpars2_191_(__Stack0) ->
+yeccpars2_190_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_194_/1}).
+-compile({inline,yeccpars2_193_/1}).
 -file("src/graphql_parser.yrl", 47).
-yeccpars2_194_(__Stack0) ->
+yeccpars2_193_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_195_/1}).
+-compile({inline,yeccpars2_194_/1}).
 -file("src/graphql_parser.yrl", 48).
-yeccpars2_195_(__Stack0) ->
+yeccpars2_194_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } , { defaultValue , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_196_/1}).
+-compile({inline,yeccpars2_195_/1}).
 -file("src/graphql_parser.yrl", 46).
-yeccpars2_196_(__Stack0) ->
+yeccpars2_195_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_197_/1}).
+-compile({inline,yeccpars2_196_/1}).
 -file("src/graphql_parser.yrl", 44).
-yeccpars2_197_(__Stack0) ->
+yeccpars2_196_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_198_/1}).
+-compile({inline,yeccpars2_197_/1}).
 -file("src/graphql_parser.yrl", 36).
-yeccpars2_198_(__Stack0) ->
+yeccpars2_197_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_199_/1}).
+-compile({inline,yeccpars2_198_/1}).
 -file("src/graphql_parser.yrl", 35).
-yeccpars2_199_(__Stack0) ->
+yeccpars2_198_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { variableDefinitions , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_201_/1}).
+-compile({inline,yeccpars2_200_/1}).
 -file("src/graphql_parser.yrl", 37).
-yeccpars2_201_(__Stack0) ->
+yeccpars2_200_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { variableDefinitions , __3 } , { directives , __4 } , { selectionSet , __5 } ] )

--- a/src/graphql_parser.erl
+++ b/src/graphql_parser.erl
@@ -1,6 +1,6 @@
 -module(graphql_parser).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("src/graphql_parser.yrl", 191).
+-file("src/graphql_parser.yrl", 204).
 
 extract_atom({Value, _Line}) -> Value.
 extract_token({_Token, _Line, Value}) -> Value.
@@ -10,13 +10,14 @@ extract_float({_Token, _Line, Value}) ->
   {Float, []} = string:to_float(Value), Float.
 extract_boolean({_Token, _Line, "true"}) -> true;
 extract_boolean({_Token, _Line, "false"}) -> false.
+extract_keyword({Value, _Line}) -> atom_to_list(Value).
 
 build_ast_node(Type, Tuple) when is_list(Tuple) ->
   [{kind, Type}, {loc, [{start, 0}]}] ++ Tuple;
 build_ast_node(Type, Tuple) when is_tuple(Tuple) ->
   [{kind, Type}, {loc, [{start, 0}]}, Tuple].
 
--file("/usr/local/Cellar/erlang/17.4_1/lib/erlang/lib/parsetools-2.0.12/include/yeccpre.hrl", 0).
+-file("/usr/local/Cellar/erlang/17.5/lib/erlang/lib/parsetools-2.0.12/include/yeccpre.hrl", 0).
 %%
 %% %CopyrightBegin%
 %%
@@ -200,7 +201,7 @@ yecctoken2string(Other) ->
 
 
 
--file("src/graphql_parser.erl", 203).
+-file("src/graphql_parser.erl", 204).
 
 yeccpars2(0=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_0(S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -274,66 +275,66 @@ yeccpars2(34=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_34(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(35=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(36=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_36(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(37=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_37(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(36=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_36(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(37=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_37(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(38=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(39=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_39(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(40=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_40(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(41=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_41(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(42=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_42(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(43=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_43(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(44=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_44(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_38(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(39=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_39(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(40=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_40(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(41=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_41(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(42=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_42(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(43=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_43(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(44=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_44(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(45=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(46=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_46(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(47=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_47(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_45(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(46=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_46(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(47=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_47(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(48=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_48(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(49=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_49(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(50=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_50(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(51=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(51=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(52=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_52(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(53=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(54=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(53=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_53(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(54=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_54(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(55=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(56=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(57=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_57(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(58=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_58(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(58=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(59=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_59(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(60=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_60(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(61=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(62=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_62(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(63=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_63(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(64=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_64(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(65=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_65(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(62=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_62(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(63=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_63(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(64=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_64(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(65=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_65(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(66=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(67=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -344,24 +345,24 @@ yeccpars2(67=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_69(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(70=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_70(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(71=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(72=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(71=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_71(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(72=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_72(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(73=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_73(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(74=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_74(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(74=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(75=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_75(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(76=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_76(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(77=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_77(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(76=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_76(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(77=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_77(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(78=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_78(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(79=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_79(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(79=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_79(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(80=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_80(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(81=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -370,32 +371,32 @@ yeccpars2(80=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_82(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(83=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_83(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(84=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_84(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(85=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_85(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(84=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_84(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(85=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(86=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_86(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(87=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_87(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(88=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_88(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(88=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_88(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(89=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_89(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(90=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_90(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(91=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_91(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(91=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_91(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(92=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_92(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(93=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_93(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(93=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_93(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(94=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_94(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(95=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_95(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(96=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_96(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(96=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_96(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(97=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_97(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(98=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -406,180 +407,206 @@ yeccpars2(96=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_100(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(101=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_101(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(102=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_102(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(102=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_102(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(103=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_103(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(104=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(104=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_104(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(105=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_105(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(106=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_106(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(107=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(107=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_107(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(108=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_108(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(109=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_109(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(109=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_109(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(110=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_110(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(111=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(112=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(111=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_111(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(112=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_112(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(113=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_113(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(114=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_114(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(115=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_115(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(115=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_115(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(116=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_116(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(117=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_117(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(118=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_118(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(119=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(119=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_119(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(120=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_120(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(121=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_121(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(122=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_122(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(123=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_123(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(124=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_124(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(124=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(125=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_120(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(126=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_126(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(127=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_127(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(128=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_128(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(129=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_129(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(130=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_130(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(127=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_127(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(128=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_128(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(129=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_129(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(130=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_130(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(131=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_131(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(132=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(133=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(134=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(135=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_120(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(132=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(133=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(134=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(135=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_135(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(136=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_136(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(137=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_137(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(138=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(139=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_139(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(140=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_120(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(141=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_141(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(142=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_142(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_140(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(141=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_141(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(142=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_142(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(143=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_143(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(144=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_144(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(145=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(145=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_145(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(146=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_146(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(147=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_147(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(148=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_148(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(148=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(149=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_149(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(150=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(151=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_151(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(152=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_152(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(153=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_153(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(154=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(150=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_150(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(151=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(152=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_152(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(153=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(154=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_154(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(155=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_155(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(156=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_156(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(156=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_156(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(157=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_157(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(158=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(159=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_39(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(160=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_160(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_159(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(160=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_160(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(161=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_43(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_161(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(162=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_162(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(163=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_163(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(163=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(164=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_164(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(165=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_165(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(166=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_166(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(167=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_167(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(167=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(168=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_168(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(169=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_169(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(170=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_170(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(171=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_171(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(169=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_169(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(170=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_170(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(171=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(172=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_172(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_52(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(173=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_39(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_173(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(174=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_174(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(175=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_43(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(176=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_176(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_175(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(176=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_176(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(177=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_177(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(178=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_178(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(178=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(179=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_179(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(180=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_120(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(180=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_180(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(181=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_181(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(182=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_182(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(183=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_183(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(184=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_184(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(183=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_183(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(184=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_184(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(185=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_185(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(186=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_186(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_52(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(187=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_43(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_187(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(188=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_188(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(189=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_189(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(190=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_190(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(191=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_191(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(192=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_192(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(193=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(194=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_194(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(195=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_195(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(196=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_196(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(197=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_197(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(198=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_198(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(199=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_199(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(200=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(201=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_201(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -624,9 +651,38 @@ yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccpars2_5(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'TypeDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_6(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_cont_6(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(_, _, _, _, T, _, _) ->
+yeccpars2_cont_6(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_cont_6(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_7(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -711,30 +767,56 @@ yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 yeccpars2_26(S, '...', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 34, Ss, Stack, T, Ts, Tzr);
-yeccpars2_26(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_26(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_26(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_27(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 102, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 115, Ss, Stack, T, Ts, Tzr);
 yeccpars2_27(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_28(S, '...', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 34, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_28_(Stack),
  'yeccgoto_\'Selections\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_29(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 96, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 109, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -752,783 +834,1045 @@ yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 %% yeccpars2_33: see yeccpars2_6
 
-yeccpars2_34(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
 yeccpars2_34(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_34(_, _, _, _, T, _, _) ->
- yeccerror(T).
+ yeccpars1(S, 51, Ss, Stack, T, Ts, Tzr);
+yeccpars2_34(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_35(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_35_(Stack),
  'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_36(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'FragmentName\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+ NewStack = yeccpars2_36_(Stack),
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_37(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
 yeccpars2_37(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_37_(Stack),
- 'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_38: see yeccpars2_6
+yeccpars2_38(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_38_(Stack),
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_39(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_39(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_39(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_39(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_39_(Stack),
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'TypeCondition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+ NewStack = yeccpars2_40_(Stack),
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_41_(Stack),
- 'yeccgoto_\'NamedType\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_42_(Stack),
- 'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_43(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_43(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_43(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_43_(Stack),
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_44(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
 yeccpars2_44(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_44_(Stack),
- 'yeccgoto_\'Directives\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_45: see yeccpars2_6
+yeccpars2_45(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_45_(Stack),
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_46(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_46(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_46_(Stack),
- 'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_47(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
  NewStack = yeccpars2_47_(Stack),
- 'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_48: see yeccpars2_6
+yeccpars2_48(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_48_(Stack),
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_49(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 54, Ss, Stack, T, Ts, Tzr);
-yeccpars2_49(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'FragmentName\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_50(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 53, Ss, Stack, T, Ts, Tzr);
-yeccpars2_50(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_50(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
+yeccpars2_50(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_50_(Stack),
+ 'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_51(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_51(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_51(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_51_(Stack),
- 'yeccgoto_\'ArgumentList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_52_(Stack),
- 'yeccgoto_\'ArgumentList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_53_(Stack),
- 'yeccgoto_\'Arguments\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_54(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 62, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 63, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(S, float_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 64, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(S, int_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 65, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(S, string_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 66, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 67, Ss, Stack, T, Ts, Tzr);
-yeccpars2_54(_, _, _, _, T, _, _) ->
+yeccpars2_52(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
+yeccpars2_52(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_52(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
+yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'TypeCondition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_54_(Stack),
+ 'yeccgoto_\'NamedType\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
 yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_55_(Stack),
+ 'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_56(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_56_(Stack),
- 'yeccgoto_\'Argument\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_56(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_56(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
+yeccpars2_57(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
 yeccpars2_57(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_57_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Directives\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'EnumValue\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+%% yeccpars2_58: see yeccpars2_6
 
+yeccpars2_59(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
 yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
  NewStack = yeccpars2_59_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_60_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 %% yeccpars2_61: see yeccpars2_6
 
-yeccpars2_62(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 62, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 63, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, float_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 64, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, int_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 65, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, string_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 66, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_62(S, ':', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 67, Ss, Stack, T, Ts, Tzr);
 yeccpars2_62(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_63(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_63_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+yeccpars2_63(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 66, Ss, Stack, T, Ts, Tzr);
+yeccpars2_63(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
+yeccpars2_64(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_64(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_64_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ArgumentList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_65(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
  NewStack = yeccpars2_65_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ArgumentList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_66(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_66_(Stack),
+ 'yeccgoto_\'Arguments\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_67(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, '[', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
+yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_69_(Stack),
+ 'yeccgoto_\'Argument\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_70_(Stack),
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_67(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 71, Ss, Stack, T, Ts, Tzr);
-yeccpars2_67(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_68(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
-yeccpars2_68(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_69(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_69_(Stack),
- 'yeccgoto_\'ObjectFields\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
-
-yeccpars2_70(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 72, Ss, Stack, T, Ts, Tzr);
-yeccpars2_70(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
 yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_71_(Stack),
- 'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'EnumValue\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-%% yeccpars2_72: see yeccpars2_54
+yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_72_(Stack),
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
  NewStack = yeccpars2_73_(Stack),
- 'yeccgoto_\'ObjectField\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_74_(Stack),
- 'yeccgoto_\'ObjectFields\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_74: see yeccpars2_6
 
-yeccpars2_75(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_75_(Stack),
- 'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_76(S, ']', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_75(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, '[', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 91, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
+yeccpars2_75(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
-yeccpars2_76(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_75(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_77(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
-yeccpars2_77(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 62, Ss, Stack, T, Ts, Tzr);
-yeccpars2_77(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 63, Ss, Stack, T, Ts, Tzr);
-yeccpars2_77(S, float_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 64, Ss, Stack, T, Ts, Tzr);
-yeccpars2_77(S, int_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 65, Ss, Stack, T, Ts, Tzr);
-yeccpars2_77(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_77(S, string_value, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 66, Ss, Stack, T, Ts, Tzr);
-yeccpars2_77(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 67, Ss, Stack, T, Ts, Tzr);
+yeccpars2_76(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_76_(Stack),
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
 yeccpars2_77(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_77_(Stack),
- 'yeccgoto_\'Values\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_78(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_78_(Stack),
- 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_79(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_79_(Stack),
- 'yeccgoto_\'Values\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_80(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_80_(Stack),
- 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_80(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_80(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 84, Ss, Stack, T, Ts, Tzr);
+yeccpars2_80(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_81(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_81_(Stack),
- 'yeccgoto_\'Variable\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_81(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 88, Ss, Stack, T, Ts, Tzr);
+yeccpars2_81(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
+yeccpars2_82(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_82(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_82_(Stack),
- 'yeccgoto_\'Directives\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ObjectFields\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_83(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_83_(Stack),
- 'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_83(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 85, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_84(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_84_(Stack),
- 'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_85(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
-yeccpars2_85(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_85(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_85(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_85_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_84_(Stack),
+ 'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_85: see yeccpars2_67
 
 yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_86_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ObjectField\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_87(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_87(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_87_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ObjectFields\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_88(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_88(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_88(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_88_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_89(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_89_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_89(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 93, Ss, Stack, T, Ts, Tzr);
+yeccpars2_89(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
+yeccpars2_90(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, '[', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_90(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
 yeccpars2_90(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_90_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Values\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_91(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_91_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_92(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_92_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Values\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_93_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_94(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_94(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_94_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Variable\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_95(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_95(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_95_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Directives\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_96_(Stack),
- 'yeccgoto_\'Alias\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_97_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_98(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
+yeccpars2_98(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
 yeccpars2_98(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_98(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_98_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_99(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_99_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_100(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_100(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_100_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_101(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
+yeccpars2_101(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_101(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_101_(Stack),
- 'yeccgoto_\'Selections\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_102(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_102_(Stack),
- 'yeccgoto_\'SelectionSet\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_103(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 104, Ss, Stack, T, Ts, Tzr);
-yeccpars2_103(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_103(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_103(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_103_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_104: see yeccpars2_6
+yeccpars2_104(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_104_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_105_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_106(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_106_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_107(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_107(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_107_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_108(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
+yeccpars2_108(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_108(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_108_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_109(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_109_(Stack),
+ 'yeccgoto_\'Alias\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_110(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_110_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_111(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_111(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_111_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_112(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_112_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_113_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_114(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_114_(Stack),
+ 'yeccgoto_\'Selections\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_115(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_115_(Stack),
+ 'yeccgoto_\'SelectionSet\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_116(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 117, Ss, Stack, T, Ts, Tzr);
+yeccpars2_116(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+%% yeccpars2_117: see yeccpars2_6
+
+yeccpars2_118(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_118_(Stack),
  'yeccgoto_\'UnionTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_106(S, '|', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 107, Ss, Stack, T, Ts, Tzr);
-yeccpars2_106(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_106_(Stack),
+yeccpars2_119(S, '|', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 120, Ss, Stack, T, Ts, Tzr);
+yeccpars2_119(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_119_(Stack),
  'yeccgoto_\'UnionMembers\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_107: see yeccpars2_6
-
-yeccpars2_108(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_108_(Stack),
- 'yeccgoto_\'UnionMembers\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_109(S, implements, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 111, Ss, Stack, T, Ts, Tzr);
-yeccpars2_109(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 112, Ss, Stack, T, Ts, Tzr);
-yeccpars2_109(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_110(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 145, Ss, Stack, T, Ts, Tzr);
-yeccpars2_110(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-%% yeccpars2_111: see yeccpars2_6
-
-%% yeccpars2_112: see yeccpars2_6
-
-yeccpars2_113(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 119, Ss, Stack, T, Ts, Tzr);
-yeccpars2_113(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 120, Ss, Stack, T, Ts, Tzr);
-yeccpars2_113(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_114(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 117, Ss, Stack, T, Ts, Tzr);
-yeccpars2_114(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_115(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_115(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_115_(Stack),
- 'yeccgoto_\'FieldDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
-
-yeccpars2_116(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_116_(Stack),
- 'yeccgoto_\'FieldDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_117(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_117_(Stack),
- 'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_118(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 140, Ss, Stack, T, Ts, Tzr);
-yeccpars2_118(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-%% yeccpars2_119: see yeccpars2_6
-
-yeccpars2_120(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 125, Ss, Stack, T, Ts, Tzr);
-yeccpars2_120(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_120(_, _, _, _, T, _, _) ->
- yeccerror(T).
+%% yeccpars2_120: see yeccpars2_6
 
 yeccpars2_121(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_121_(Stack),
- 'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'UnionMembers\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_122(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 124, Ss, Stack, T, Ts, Tzr);
+yeccpars2_122(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 125, Ss, Stack, T, Ts, Tzr);
+yeccpars2_122(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_123(S, '!', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 129, Ss, Stack, T, Ts, Tzr);
-yeccpars2_123(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_123(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 158, Ss, Stack, T, Ts, Tzr);
+yeccpars2_123(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_124(S, '!', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 128, Ss, Stack, T, Ts, Tzr);
-yeccpars2_124(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+%% yeccpars2_124: see yeccpars2_6
 
-%% yeccpars2_125: see yeccpars2_120
+%% yeccpars2_125: see yeccpars2_6
 
-yeccpars2_126(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 127, Ss, Stack, T, Ts, Tzr);
+yeccpars2_126(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 132, Ss, Stack, T, Ts, Tzr);
+yeccpars2_126(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 133, Ss, Stack, T, Ts, Tzr);
 yeccpars2_126(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_127(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_127_(Stack),
- 'yeccgoto_\'ListType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_127(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 130, Ss, Stack, T, Ts, Tzr);
+yeccpars2_127(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
+yeccpars2_128(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_128(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_128(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_128_(Stack),
- 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'FieldDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_129(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_129_(Stack),
- 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'FieldDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_130(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 135, Ss, Stack, T, Ts, Tzr);
-yeccpars2_130(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_130(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_130_(Stack),
+ 'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_131(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 134, Ss, Stack, T, Ts, Tzr);
+yeccpars2_131(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 153, Ss, Stack, T, Ts, Tzr);
 yeccpars2_131(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_132(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_132(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_132_(Stack),
- 'yeccgoto_\'InputValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+%% yeccpars2_132: see yeccpars2_6
 
-yeccpars2_133(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_133_(Stack),
- 'yeccgoto_\'InputValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_133(S, '[', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 138, Ss, Stack, T, Ts, Tzr);
+yeccpars2_133(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_cont_6(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_134_(Stack),
- 'yeccgoto_\'ArgumentsDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_135: see yeccpars2_120
+yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_136(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 138, Ss, Stack, T, Ts, Tzr);
+yeccpars2_136(S, '!', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 142, Ss, Stack, T, Ts, Tzr);
 yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_136_(Stack),
- 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
+yeccpars2_137(S, '!', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 141, Ss, Stack, T, Ts, Tzr);
 yeccpars2_137(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_137_(Stack),
- 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-%% yeccpars2_138: see yeccpars2_54
+%% yeccpars2_138: see yeccpars2_133
 
-yeccpars2_139(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_139_(Stack),
- 'yeccgoto_\'DefaultValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_139(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 140, Ss, Stack, T, Ts, Tzr);
+yeccpars2_139(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-%% yeccpars2_140: see yeccpars2_120
+yeccpars2_140(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_140_(Stack),
+ 'yeccgoto_\'ListType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_141(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_141_(Stack),
- 'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_142(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_142_(Stack),
- 'yeccgoto_\'ImplementsInterfaces\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_143(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_143(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_143_(Stack),
- 'yeccgoto_\'NamedTypeList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
-
-yeccpars2_144(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_144_(Stack),
- 'yeccgoto_\'NamedTypeList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-%% yeccpars2_145: see yeccpars2_6
-
-yeccpars2_146(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 147, Ss, Stack, T, Ts, Tzr);
-yeccpars2_146(_, _, _, _, T, _, _) ->
+yeccpars2_143(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 148, Ss, Stack, T, Ts, Tzr);
+yeccpars2_143(_, _, _, _, T, _, _) ->
  yeccerror(T).
+
+yeccpars2_144(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 147, Ss, Stack, T, Ts, Tzr);
+yeccpars2_144(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_145(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_145_(Stack),
+ 'yeccgoto_\'InputValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_146(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_146_(Stack),
+ 'yeccgoto_\'InputValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_147(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_147_(Stack),
- 'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ArgumentsDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_148(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_148_(Stack),
- 'yeccgoto_\'ScalarTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_148: see yeccpars2_133
 
-yeccpars2_149(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 150, Ss, Stack, T, Ts, Tzr);
-yeccpars2_149(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_149(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 151, Ss, Stack, T, Ts, Tzr);
+yeccpars2_149(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_149_(Stack),
+ 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_150: see yeccpars2_6
+yeccpars2_150(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_150_(Stack),
+ 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_151(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 152, Ss, Stack, T, Ts, Tzr);
-yeccpars2_151(_, _, _, _, T, _, _) ->
- yeccerror(T).
+%% yeccpars2_151: see yeccpars2_67
 
 yeccpars2_152(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_152_(Stack),
- 'yeccgoto_\'InterfaceTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'DefaultValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_153(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 154, Ss, Stack, T, Ts, Tzr);
-yeccpars2_153(_, _, _, _, T, _, _) ->
- yeccerror(T).
+%% yeccpars2_153: see yeccpars2_133
 
-%% yeccpars2_154: see yeccpars2_6
+yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_154_(Stack),
+ 'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_155(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 156, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_155(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_155_(Stack),
+ 'yeccgoto_\'ImplementsInterfaces\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_156(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_156(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
 yeccpars2_156(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_156_(Stack),
- 'yeccgoto_\'InputObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NamedTypeList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_157(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 158, Ss, Stack, T, Ts, Tzr);
-yeccpars2_157(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_157(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_157_(Stack),
+ 'yeccgoto_\'NamedTypeList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 %% yeccpars2_158: see yeccpars2_6
 
-%% yeccpars2_159: see yeccpars2_39
+yeccpars2_159(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 160, Ss, Stack, T, Ts, Tzr);
+yeccpars2_159(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_160(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_160_(Stack),
- 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-%% yeccpars2_161: see yeccpars2_43
-
-yeccpars2_162(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_162_(Stack),
- 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_160_(Stack),
+ 'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_163(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_161(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_163_(Stack),
- 'yeccgoto_\'TypeExtensionDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_161_(Stack),
+ 'yeccgoto_\'ScalarTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_164(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_162(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 163, Ss, Stack, T, Ts, Tzr);
+yeccpars2_162(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+%% yeccpars2_163: see yeccpars2_6
+
+yeccpars2_164(S, '}', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 165, Ss, Stack, T, Ts, Tzr);
 yeccpars2_164(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_165: see yeccpars2_6
+yeccpars2_165(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_165_(Stack),
+ 'yeccgoto_\'InterfaceTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_166(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 170, Ss, Stack, T, Ts, Tzr);
+yeccpars2_166(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 167, Ss, Stack, T, Ts, Tzr);
 yeccpars2_166(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_167(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_167(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_167_(Stack),
- 'yeccgoto_\'EnumValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+%% yeccpars2_167: see yeccpars2_6
 
-yeccpars2_168(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'EnumValueDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_168(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 169, Ss, Stack, T, Ts, Tzr);
+yeccpars2_168(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_169(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_169_(Stack),
- 'yeccgoto_\'EnumValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_170(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_170_(Stack),
- 'yeccgoto_\'EnumTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_169_(Stack),
+ 'yeccgoto_\'InputObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_171(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_170(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 171, Ss, Stack, T, Ts, Tzr);
+yeccpars2_170(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+%% yeccpars2_171: see yeccpars2_6
+
+%% yeccpars2_172: see yeccpars2_52
+
+yeccpars2_173(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_173_(Stack),
+ 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_174: see yeccpars2_56
+
+yeccpars2_175(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_175_(Stack),
+ 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_176(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_171_(Stack),
- 'yeccgoto_\'Definitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_176_(Stack),
+ 'yeccgoto_\'TypeExtensionDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_172(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 176, Ss, Stack, T, Ts, Tzr);
-yeccpars2_172(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_172(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_172(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-%% yeccpars2_173: see yeccpars2_39
-
-yeccpars2_174(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_174_(Stack),
- 'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-%% yeccpars2_175: see yeccpars2_43
-
-yeccpars2_176(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
-yeccpars2_176(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_177(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 184, Ss, Stack, T, Ts, Tzr);
+yeccpars2_177(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 178, Ss, Stack, T, Ts, Tzr);
 yeccpars2_177(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_178(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 61, Ss, Stack, T, Ts, Tzr);
-yeccpars2_178(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_178_(Stack),
- 'yeccgoto_\'VariableDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+%% yeccpars2_178: see yeccpars2_6
 
-yeccpars2_179(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 180, Ss, Stack, T, Ts, Tzr);
+yeccpars2_179(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 183, Ss, Stack, T, Ts, Tzr);
 yeccpars2_179(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_180: see yeccpars2_120
+yeccpars2_180(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_180_(Stack),
+ 'yeccgoto_\'EnumValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_181(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 138, Ss, Stack, T, Ts, Tzr);
 yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_181_(Stack),
- 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'EnumValueDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_182_(Stack),
- 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'EnumValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_183_(Stack),
- 'yeccgoto_\'VariableDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'EnumTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_184(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_184_(Stack),
+ 'yeccgoto_\'Definitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_185(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 189, Ss, Stack, T, Ts, Tzr);
+yeccpars2_185(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 58, Ss, Stack, T, Ts, Tzr);
+yeccpars2_185(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_185(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+%% yeccpars2_186: see yeccpars2_52
+
+yeccpars2_187(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_187_(Stack),
+ 'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_188: see yeccpars2_56
+
+yeccpars2_189(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
+yeccpars2_189(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_190(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 197, Ss, Stack, T, Ts, Tzr);
+yeccpars2_190(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_191(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
+yeccpars2_191(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_191_(Stack),
+ 'yeccgoto_\'VariableDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_192(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 193, Ss, Stack, T, Ts, Tzr);
+yeccpars2_192(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+%% yeccpars2_193: see yeccpars2_133
+
+yeccpars2_194(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 151, Ss, Stack, T, Ts, Tzr);
+yeccpars2_194(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_194_(Stack),
+ 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_195(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_195_(Stack),
+ 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_196(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_196_(Stack),
+ 'yeccgoto_\'VariableDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_197(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_197_(Stack),
  'yeccgoto_\'VariableDefinitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_185(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_198(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_185_(Stack),
+ NewStack = yeccpars2_198_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_186(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_199(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_186_(Stack),
+ NewStack = yeccpars2_199_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_187: see yeccpars2_43
+%% yeccpars2_200: see yeccpars2_56
 
-yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_188_(Stack),
+ NewStack = yeccpars2_201_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 'yeccgoto_\'Alias\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -1536,30 +1880,30 @@ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'Alias\''(28, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(33, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Argument\''(48, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_51(51, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Argument\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_51(51, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Argument\''(61, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_64(64, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Argument\''(64, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_64(64, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ArgumentList\''(48, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_50(50, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ArgumentList\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ArgumentList\''(61, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_63(63, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ArgumentList\''(64=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_65(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Arguments\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_95(95, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Arguments\''(46=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_47(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Arguments\''(85, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_88(88, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_108(108, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Arguments\''(59=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Arguments\''(98, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_101(101, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ArgumentsDefinition\''(113, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_118(118, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ArgumentsDefinition\''(126, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_131(131, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'DefaultValue\''(136=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_137(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'DefaultValue\''(181=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'DefaultValue\''(149=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_150(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'DefaultValue\''(194=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_195(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Definition\''(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_15(15, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1569,49 +1913,49 @@ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'Definitions\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Definitions\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_171(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_184(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Directive\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(37, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(39, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(44, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(85, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(88, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(95, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(159, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(50, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(52, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(57, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(98, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(101, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(108, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Directive\''(172, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(173, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(44, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(186, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Directives\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_94(94, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(37=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_84(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(39, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_43(43, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(44=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_82(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(85, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_87(87, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(88, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_90(90, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(95, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_98(98, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(159, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_43(161, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_107(107, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(50=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(52, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(57=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(98, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_100(100, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(101, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_103(103, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(108, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_111(111, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Directives\''(172, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_43(175, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(173, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_43(187, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_56(174, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(188, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(186, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(200, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Document\''(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_13(13, Cat, Ss, Stack, T, Ts, Tzr).
@@ -1621,53 +1965,53 @@ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'EnumTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_12(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValue\''(54=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(62=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(72=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(77=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(165=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_168(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(167=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_168(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'EnumValue\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(178=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(180=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValueDefinition\''(165, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_167(167, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValueDefinition\''(167, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_167(167, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'EnumValueDefinition\''(178, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_180(180, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValueDefinition\''(180, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_180(180, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValueDefinitionList\''(165, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_166(166, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValueDefinitionList\''(167=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_169(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'EnumValueDefinitionList\''(178, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_179(179, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValueDefinitionList\''(180=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Field\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Field\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'FieldDefinition\''(112, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_115(115, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(115, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_115(115, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(145, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_115(115, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(150, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_115(115, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'FieldDefinition\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(128, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(158, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(163, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'FieldDefinitionList\''(112, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_114(114, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(115=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_116(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(145, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_146(146, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(150, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_151(151, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'FieldDefinitionList\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(128=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_129(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(158, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_159(159, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(163, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_164(164, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1675,17 +2019,17 @@ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentName\''(18, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_157(157, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_170(170, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'FragmentName\''(34, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_37(37, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_50(50, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentSpread\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'FragmentSpread\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ImplementsInterfaces\''(109, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_110(110, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ImplementsInterfaces\''(122, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'InlineFragment\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_30(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1697,200 +2041,200 @@ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'InputObjectTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'InputValueDefinition\''(119, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(132, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'InputValueDefinition\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(132, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinition\''(154, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(132, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_145(145, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinition\''(145, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_145(145, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinition\''(167, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_145(145, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'InputValueDefinitionList\''(119, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_131(131, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinitionList\''(132=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_133(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinitionList\''(154, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_155(155, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'InputValueDefinitionList\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinitionList\''(145=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_146(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinitionList\''(167, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_168(168, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'InterfaceTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'InterfaceTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ListType\''(120, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_124(124, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_124(124, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(135, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_124(124, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(140, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_124(124, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(180, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_124(124, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ListType\''(133, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(138, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(148, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(153, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(193, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ListValue\''(54=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(62=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(72=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(77=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ListValue\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Name\''(6, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_172(172, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_185(185, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(16, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_164(164, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_177(177, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(18=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_36(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(19, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_153(153, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_166(166, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(20, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_149(149, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_162(162, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(23=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_148(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_161(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(24, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_109(109, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_122(122, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(25, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_103(103, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_116(116, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_29(29, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(28, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_29(29, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(33, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_85(85, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_98(98, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_36(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(38=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(45, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_46(46, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(48, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_49(49, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_49(49, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(54=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(61=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_81(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(62=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(67, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(70, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(69, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(70, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(72=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(77=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(104=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(107=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(111=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(112, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_113(113, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(115, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_113(113, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(119, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_130(130, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(58, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_59(59, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(61, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_62(62, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(64, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_62(62, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_94(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(80, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_83(83, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(82, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_83(83, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(117=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(120=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(125=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(124=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(128, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_130(130, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(135=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(133=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(140=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(143=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(145, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_113(113, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(150, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_113(113, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(154, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_130(130, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(158=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(165=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(167=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(148=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(153=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(156=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(158, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(163, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(167, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(171=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(178=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(180=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(193=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'NamedType\''(38=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(104, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_106(106, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(107, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_106(106, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(111, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(117, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_119(119, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'NamedType\''(120, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(135, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(140, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(143, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(158=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(180, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_119(119, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_156(156, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(133, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(138, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(148, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(153, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(156, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_156(156, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(171=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(193, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'NamedTypeList\''(111=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_142(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedTypeList\''(143=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_144(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'NamedTypeList\''(124=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_155(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedTypeList\''(156=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_157(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'NonNullType\''(120=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(125=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(135=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(140=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(180=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'NonNullType\''(133=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(148=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(153=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(193=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectField\''(67, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(69, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectField\''(69, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(69, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ObjectField\''(80, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectField\''(82, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectFields\''(67, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_68(68, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectFields\''(69=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ObjectFields\''(80, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_81(81, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectFields\''(82=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_87(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'ObjectTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'ObjectTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'ObjectTypeDefinition\''(17=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_163(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_176(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectValue\''(54=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(62=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(72=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(77=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_57(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ObjectValue\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'OperationDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_7(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1917,58 +2261,58 @@ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'SelectionSet\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(29=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(39=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(43=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_83(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(87=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_92(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(88=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_89(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_91(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(94=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_100(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(95=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_106(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(52=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(56=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(98=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_99(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(159=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_160(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(161=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_162(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(100=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(101=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_102(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(103=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_104(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(107=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(108=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_110(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(111=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_112(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(172=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_174(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(173=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_186(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(175=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_185(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(187=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_173(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(174=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_175(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(185=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_187(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(186=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_199(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(188=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_198(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(200=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_201(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Selections\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_27(27, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Selections\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_101(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_114(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Type\''(120=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_121(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(135, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(140=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_141(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(180, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_181(181, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Type\''(133=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(138, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_139(139, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(148, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_149(149, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(153=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(193, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_194(194, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'TypeCondition\''(38, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_39(39, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'TypeCondition\''(158, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_39(159, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'TypeCondition\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_52(52, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'TypeCondition\''(171, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_52(172, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'TypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1980,59 +2324,59 @@ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'TypeExtensionDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_2(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'UnionMembers\''(104=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'UnionMembers\''(107=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_108(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'UnionMembers\''(117=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_118(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'UnionMembers\''(120=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_121(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'UnionTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'UnionTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Value\''(54=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(62, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_77(77, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(72=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(77, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_77(77, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_139(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Value\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(75, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_90(90, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(90, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_90(90, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_152(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Values\''(62, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_76(76, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Values\''(77=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_79(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Values\''(75, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_89(89, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Values\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_92(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Variable\''(54=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(62=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(72=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(77=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(138=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(176, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_179(179, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(178, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_179(179, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Variable\''(67=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(85=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(90=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(151=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(189, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_192(192, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(191, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_192(192, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinition\''(176, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_178(178, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'VariableDefinition\''(178, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_178(178, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'VariableDefinition\''(189, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_191(191, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'VariableDefinition\''(191, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_191(191, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinitionList\''(176, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_177(177, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'VariableDefinitionList\''(178=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'VariableDefinitionList\''(189, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_190(190, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'VariableDefinitionList\''(191=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_196(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinitions\''(172, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_39(173, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'VariableDefinitions\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_52(186, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_4_/1}).
 -file("src/graphql_parser.yrl", 33).
@@ -2091,716 +2435,828 @@ yeccpars2_29_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_35_/1}).
--file("src/graphql_parser.yrl", 107).
+-file("src/graphql_parser.yrl", 117).
 yeccpars2_35_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_36_/1}).
+-file("src/graphql_parser.yrl", 119).
+yeccpars2_36_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_37_/1}).
+-file("src/graphql_parser.yrl", 110).
+yeccpars2_37_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_38_/1}).
+-file("src/graphql_parser.yrl", 113).
+yeccpars2_38_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_39_/1}).
+-file("src/graphql_parser.yrl", 118).
+yeccpars2_39_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_40_/1}).
+-file("src/graphql_parser.yrl", 114).
+yeccpars2_40_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_41_/1}).
+-file("src/graphql_parser.yrl", 109).
+yeccpars2_41_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_42_/1}).
+-file("src/graphql_parser.yrl", 107).
+yeccpars2_42_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    extract_token ( __1 )
   end | __Stack].
 
--compile({inline,yeccpars2_37_/1}).
+-compile({inline,yeccpars2_43_/1}).
+-file("src/graphql_parser.yrl", 120).
+yeccpars2_43_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_44_/1}).
+-file("src/graphql_parser.yrl", 111).
+yeccpars2_44_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_45_/1}).
+-file("src/graphql_parser.yrl", 108).
+yeccpars2_45_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_46_/1}).
+-file("src/graphql_parser.yrl", 116).
+yeccpars2_46_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_47_/1}).
+-file("src/graphql_parser.yrl", 112).
+yeccpars2_47_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_48_/1}).
+-file("src/graphql_parser.yrl", 115).
+yeccpars2_48_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_50_/1}).
 -file("src/graphql_parser.yrl", 70).
-yeccpars2_37_(__Stack0) ->
+yeccpars2_50_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentSpread' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_41_/1}).
+-compile({inline,yeccpars2_51_/1}).
+-file("src/graphql_parser.yrl", 111).
+yeccpars2_51_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_54_/1}).
 -file("src/graphql_parser.yrl", 56).
-yeccpars2_41_(__Stack0) ->
+yeccpars2_54_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'NamedType' , [ { name , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_42_/1}).
+-compile({inline,yeccpars2_55_/1}).
 -file("src/graphql_parser.yrl", 73).
-yeccpars2_42_(__Stack0) ->
+yeccpars2_55_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InlineFragment' , [ { typeCondition , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_44_/1}).
+-compile({inline,yeccpars2_57_/1}).
 -file("src/graphql_parser.yrl", 102).
-yeccpars2_44_(__Stack0) ->
+yeccpars2_57_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_46_/1}).
+-compile({inline,yeccpars2_59_/1}).
 -file("src/graphql_parser.yrl", 104).
-yeccpars2_46_(__Stack0) ->
+yeccpars2_59_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Directive' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_47_/1}).
+-compile({inline,yeccpars2_60_/1}).
 -file("src/graphql_parser.yrl", 105).
-yeccpars2_47_(__Stack0) ->
+yeccpars2_60_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Directive' , [ { name , __2 } , { arguments , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_51_/1}).
+-compile({inline,yeccpars2_64_/1}).
 -file("src/graphql_parser.yrl", 98).
-yeccpars2_51_(__Stack0) ->
+yeccpars2_64_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_52_/1}).
+-compile({inline,yeccpars2_65_/1}).
 -file("src/graphql_parser.yrl", 99).
-yeccpars2_52_(__Stack0) ->
+yeccpars2_65_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_53_/1}).
+-compile({inline,yeccpars2_66_/1}).
 -file("src/graphql_parser.yrl", 97).
-yeccpars2_53_(__Stack0) ->
+yeccpars2_66_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_56_/1}).
+-compile({inline,yeccpars2_69_/1}).
 -file("src/graphql_parser.yrl", 100).
-yeccpars2_56_(__Stack0) ->
+yeccpars2_69_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Argument' , [ { name , __1 } , { value , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_57_/1}).
--file("src/graphql_parser.yrl", 116).
-yeccpars2_57_(__Stack0) ->
+-compile({inline,yeccpars2_70_/1}).
+-file("src/graphql_parser.yrl", 129).
+yeccpars2_70_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectValue' , [ { fields , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_59_/1}).
--file("src/graphql_parser.yrl", 115).
-yeccpars2_59_(__Stack0) ->
+-compile({inline,yeccpars2_72_/1}).
+-file("src/graphql_parser.yrl", 128).
+yeccpars2_72_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ListValue' , [ { values , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_60_/1}).
--file("src/graphql_parser.yrl", 114).
-yeccpars2_60_(__Stack0) ->
+-compile({inline,yeccpars2_73_/1}).
+-file("src/graphql_parser.yrl", 127).
+yeccpars2_73_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'EnumValue' , [ { value , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_63_/1}).
--file("src/graphql_parser.yrl", 113).
-yeccpars2_63_(__Stack0) ->
+-compile({inline,yeccpars2_76_/1}).
+-file("src/graphql_parser.yrl", 126).
+yeccpars2_76_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'BooleanValue' , [ { value , extract_boolean ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_64_/1}).
--file("src/graphql_parser.yrl", 111).
-yeccpars2_64_(__Stack0) ->
+-compile({inline,yeccpars2_77_/1}).
+-file("src/graphql_parser.yrl", 124).
+yeccpars2_77_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FloatValue' , [ { value , extract_float ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_65_/1}).
--file("src/graphql_parser.yrl", 110).
-yeccpars2_65_(__Stack0) ->
+-compile({inline,yeccpars2_78_/1}).
+-file("src/graphql_parser.yrl", 123).
+yeccpars2_78_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'IntValue' , [ { value , extract_integer ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_66_/1}).
--file("src/graphql_parser.yrl", 112).
-yeccpars2_66_(__Stack0) ->
+-compile({inline,yeccpars2_79_/1}).
+-file("src/graphql_parser.yrl", 125).
+yeccpars2_79_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'StringValue' , [ { value , extract_token ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_69_/1}).
--file("src/graphql_parser.yrl", 127).
-yeccpars2_69_(__Stack0) ->
+-compile({inline,yeccpars2_82_/1}).
+-file("src/graphql_parser.yrl", 140).
+yeccpars2_82_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_71_/1}).
--file("src/graphql_parser.yrl", 125).
-yeccpars2_71_(__Stack0) ->
+-compile({inline,yeccpars2_84_/1}).
+-file("src/graphql_parser.yrl", 138).
+yeccpars2_84_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ ]
   end | __Stack].
 
--compile({inline,yeccpars2_73_/1}).
--file("src/graphql_parser.yrl", 129).
-yeccpars2_73_(__Stack0) ->
+-compile({inline,yeccpars2_86_/1}).
+-file("src/graphql_parser.yrl", 142).
+yeccpars2_86_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectField' , [ { name , __1 } , { value , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_74_/1}).
--file("src/graphql_parser.yrl", 128).
-yeccpars2_74_(__Stack0) ->
+-compile({inline,yeccpars2_87_/1}).
+-file("src/graphql_parser.yrl", 141).
+yeccpars2_87_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_75_/1}).
--file("src/graphql_parser.yrl", 126).
-yeccpars2_75_(__Stack0) ->
+-compile({inline,yeccpars2_88_/1}).
+-file("src/graphql_parser.yrl", 139).
+yeccpars2_88_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_77_/1}).
--file("src/graphql_parser.yrl", 122).
-yeccpars2_77_(__Stack0) ->
+-compile({inline,yeccpars2_90_/1}).
+-file("src/graphql_parser.yrl", 135).
+yeccpars2_90_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_78_/1}).
--file("src/graphql_parser.yrl", 120).
-yeccpars2_78_(__Stack0) ->
+-compile({inline,yeccpars2_91_/1}).
+-file("src/graphql_parser.yrl", 133).
+yeccpars2_91_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ ]
   end | __Stack].
 
--compile({inline,yeccpars2_79_/1}).
--file("src/graphql_parser.yrl", 123).
-yeccpars2_79_(__Stack0) ->
+-compile({inline,yeccpars2_92_/1}).
+-file("src/graphql_parser.yrl", 136).
+yeccpars2_92_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_80_/1}).
--file("src/graphql_parser.yrl", 121).
-yeccpars2_80_(__Stack0) ->
+-compile({inline,yeccpars2_93_/1}).
+-file("src/graphql_parser.yrl", 134).
+yeccpars2_93_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_81_/1}).
+-compile({inline,yeccpars2_94_/1}).
 -file("src/graphql_parser.yrl", 49).
-yeccpars2_81_(__Stack0) ->
+yeccpars2_94_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Variable' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_82_/1}).
+-compile({inline,yeccpars2_95_/1}).
 -file("src/graphql_parser.yrl", 103).
-yeccpars2_82_(__Stack0) ->
+yeccpars2_95_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_83_/1}).
+-compile({inline,yeccpars2_96_/1}).
 -file("src/graphql_parser.yrl", 74).
-yeccpars2_83_(__Stack0) ->
+yeccpars2_96_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InlineFragment' , [ { typeCondition , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_84_/1}).
+-compile({inline,yeccpars2_97_/1}).
 -file("src/graphql_parser.yrl", 71).
-yeccpars2_84_(__Stack0) ->
+yeccpars2_97_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentSpread' , [ { name , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_85_/1}).
+-compile({inline,yeccpars2_98_/1}).
 -file("src/graphql_parser.yrl", 86).
-yeccpars2_85_(__Stack0) ->
+yeccpars2_98_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_86_/1}).
+-compile({inline,yeccpars2_99_/1}).
 -file("src/graphql_parser.yrl", 88).
-yeccpars2_86_(__Stack0) ->
+yeccpars2_99_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_87_/1}).
+-compile({inline,yeccpars2_100_/1}).
 -file("src/graphql_parser.yrl", 90).
-yeccpars2_87_(__Stack0) ->
+yeccpars2_100_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_88_/1}).
+-compile({inline,yeccpars2_101_/1}).
 -file("src/graphql_parser.yrl", 87).
-yeccpars2_88_(__Stack0) ->
+yeccpars2_101_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_89_/1}).
+-compile({inline,yeccpars2_102_/1}).
 -file("src/graphql_parser.yrl", 89).
-yeccpars2_89_(__Stack0) ->
+yeccpars2_102_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_90_/1}).
+-compile({inline,yeccpars2_103_/1}).
 -file("src/graphql_parser.yrl", 91).
-yeccpars2_90_(__Stack0) ->
+yeccpars2_103_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { directives , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_91_/1}).
+-compile({inline,yeccpars2_104_/1}).
 -file("src/graphql_parser.yrl", 93).
-yeccpars2_91_(__Stack0) ->
+yeccpars2_104_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_92_/1}).
+-compile({inline,yeccpars2_105_/1}).
 -file("src/graphql_parser.yrl", 92).
-yeccpars2_92_(__Stack0) ->
+yeccpars2_105_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_93_/1}).
+-compile({inline,yeccpars2_106_/1}).
 -file("src/graphql_parser.yrl", 81).
-yeccpars2_93_(__Stack0) ->
+yeccpars2_106_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { selectionSet , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_94_/1}).
+-compile({inline,yeccpars2_107_/1}).
 -file("src/graphql_parser.yrl", 80).
-yeccpars2_94_(__Stack0) ->
+yeccpars2_107_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { directives , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_95_/1}).
+-compile({inline,yeccpars2_108_/1}).
 -file("src/graphql_parser.yrl", 79).
-yeccpars2_95_(__Stack0) ->
+yeccpars2_108_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_96_/1}).
+-compile({inline,yeccpars2_109_/1}).
 -file("src/graphql_parser.yrl", 95).
-yeccpars2_96_(__Stack0) ->
+yeccpars2_109_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    __1
   end | __Stack].
 
--compile({inline,yeccpars2_97_/1}).
+-compile({inline,yeccpars2_110_/1}).
 -file("src/graphql_parser.yrl", 83).
-yeccpars2_97_(__Stack0) ->
+yeccpars2_110_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_98_/1}).
+-compile({inline,yeccpars2_111_/1}).
 -file("src/graphql_parser.yrl", 84).
-yeccpars2_98_(__Stack0) ->
+yeccpars2_111_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_99_/1}).
+-compile({inline,yeccpars2_112_/1}).
 -file("src/graphql_parser.yrl", 85).
-yeccpars2_99_(__Stack0) ->
+yeccpars2_112_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_100_/1}).
+-compile({inline,yeccpars2_113_/1}).
 -file("src/graphql_parser.yrl", 82).
-yeccpars2_100_(__Stack0) ->
+yeccpars2_113_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { directives , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_101_/1}).
+-compile({inline,yeccpars2_114_/1}).
 -file("src/graphql_parser.yrl", 64).
-yeccpars2_101_(__Stack0) ->
+yeccpars2_114_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_102_/1}).
+-compile({inline,yeccpars2_115_/1}).
 -file("src/graphql_parser.yrl", 61).
-yeccpars2_102_(__Stack0) ->
+yeccpars2_115_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'SelectionSet' , { selections , __2 } )
   end | __Stack].
 
--compile({inline,yeccpars2_105_/1}).
--file("src/graphql_parser.yrl", 166).
-yeccpars2_105_(__Stack0) ->
+-compile({inline,yeccpars2_118_/1}).
+-file("src/graphql_parser.yrl", 179).
+yeccpars2_118_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'UnionTypeDefinition' , [ { name , __2 } , { types , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_106_/1}).
--file("src/graphql_parser.yrl", 168).
-yeccpars2_106_(__Stack0) ->
+-compile({inline,yeccpars2_119_/1}).
+-file("src/graphql_parser.yrl", 181).
+yeccpars2_119_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_108_/1}).
--file("src/graphql_parser.yrl", 169).
-yeccpars2_108_(__Stack0) ->
+-compile({inline,yeccpars2_121_/1}).
+-file("src/graphql_parser.yrl", 182).
+yeccpars2_121_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __3 ]
   end | __Stack].
 
--compile({inline,yeccpars2_115_/1}).
--file("src/graphql_parser.yrl", 149).
-yeccpars2_115_(__Stack0) ->
+-compile({inline,yeccpars2_128_/1}).
+-file("src/graphql_parser.yrl", 162).
+yeccpars2_128_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_116_/1}).
--file("src/graphql_parser.yrl", 150).
-yeccpars2_116_(__Stack0) ->
+-compile({inline,yeccpars2_129_/1}).
+-file("src/graphql_parser.yrl", 163).
+yeccpars2_129_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_117_/1}).
--file("src/graphql_parser.yrl", 140).
-yeccpars2_117_(__Stack0) ->
+-compile({inline,yeccpars2_130_/1}).
+-file("src/graphql_parser.yrl", 153).
+yeccpars2_130_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_121_/1}).
--file("src/graphql_parser.yrl", 151).
-yeccpars2_121_(__Stack0) ->
+-compile({inline,yeccpars2_134_/1}).
+-file("src/graphql_parser.yrl", 164).
+yeccpars2_134_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { type , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_127_/1}).
+-compile({inline,yeccpars2_140_/1}).
 -file("src/graphql_parser.yrl", 57).
-yeccpars2_127_(__Stack0) ->
+yeccpars2_140_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ListType' , [ { type , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_128_/1}).
--file("src/graphql_parser.yrl", 59).
-yeccpars2_128_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_129_/1}).
--file("src/graphql_parser.yrl", 58).
-yeccpars2_129_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_132_/1}).
--file("src/graphql_parser.yrl", 156).
-yeccpars2_132_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   [ __1 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_133_/1}).
--file("src/graphql_parser.yrl", 157).
-yeccpars2_133_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   [ __1 | __2 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_134_/1}).
--file("src/graphql_parser.yrl", 154).
-yeccpars2_134_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   __2
-  end | __Stack].
-
--compile({inline,yeccpars2_136_/1}).
--file("src/graphql_parser.yrl", 159).
-yeccpars2_136_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_137_/1}).
--file("src/graphql_parser.yrl", 160).
-yeccpars2_137_(__Stack0) ->
- [__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } , { defaultValue , __4 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_139_/1}).
--file("src/graphql_parser.yrl", 51).
-yeccpars2_139_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   __2
-  end | __Stack].
-
 -compile({inline,yeccpars2_141_/1}).
--file("src/graphql_parser.yrl", 152).
+-file("src/graphql_parser.yrl", 59).
 yeccpars2_141_(__Stack0) ->
- [__4,__3,__2,__1 | __Stack] = __Stack0,
+ [__2,__1 | __Stack] = __Stack0,
  [begin
-   build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { arguments , __2 } , { type , __4 } ] )
+   build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
   end | __Stack].
 
 -compile({inline,yeccpars2_142_/1}).
--file("src/graphql_parser.yrl", 144).
+-file("src/graphql_parser.yrl", 58).
 yeccpars2_142_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   __2
+   build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_143_/1}).
--file("src/graphql_parser.yrl", 146).
-yeccpars2_143_(__Stack0) ->
+-compile({inline,yeccpars2_145_/1}).
+-file("src/graphql_parser.yrl", 169).
+yeccpars2_145_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_144_/1}).
--file("src/graphql_parser.yrl", 147).
-yeccpars2_144_(__Stack0) ->
+-compile({inline,yeccpars2_146_/1}).
+-file("src/graphql_parser.yrl", 170).
+yeccpars2_146_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
 -compile({inline,yeccpars2_147_/1}).
--file("src/graphql_parser.yrl", 142).
+-file("src/graphql_parser.yrl", 167).
 yeccpars2_147_(__Stack0) ->
- [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'ObjectTypeDefinition' , [ { name , __2 } , { interfaces , __3 } , { fields , __5 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_148_/1}).
--file("src/graphql_parser.yrl", 171).
-yeccpars2_148_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'ScalarTypeDefinition' , [ { name , __2 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_152_/1}).
--file("src/graphql_parser.yrl", 163).
-yeccpars2_152_(__Stack0) ->
- [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'InterfaceTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_156_/1}).
--file("src/graphql_parser.yrl", 182).
-yeccpars2_156_(__Stack0) ->
- [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'InputObjectTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_160_/1}).
--file("src/graphql_parser.yrl", 39).
-yeccpars2_160_(__Stack0) ->
- [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { selectionSet , __5 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_162_/1}).
--file("src/graphql_parser.yrl", 40).
-yeccpars2_162_(__Stack0) ->
- [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { directives , __5 } , { selectionSet , __6 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_163_/1}).
--file("src/graphql_parser.yrl", 185).
-yeccpars2_163_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'TypeExtensionDefinition' , [ { definition , __2 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_167_/1}).
--file("src/graphql_parser.yrl", 176).
-yeccpars2_167_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   [ __1 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_169_/1}).
--file("src/graphql_parser.yrl", 177).
-yeccpars2_169_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   [ __1 | __2 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_170_/1}).
--file("src/graphql_parser.yrl", 174).
-yeccpars2_170_(__Stack0) ->
- [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'EnumTypeDefinition' , [ { name , __2 } , { values , __4 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_171_/1}).
--file("src/graphql_parser.yrl", 24).
-yeccpars2_171_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   [ __1 | __2 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_174_/1}).
--file("src/graphql_parser.yrl", 34).
-yeccpars2_174_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { selectionSet , __3 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_178_/1}).
--file("src/graphql_parser.yrl", 45).
-yeccpars2_178_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   [ __1 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_181_/1}).
--file("src/graphql_parser.yrl", 47).
-yeccpars2_181_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_182_/1}).
--file("src/graphql_parser.yrl", 48).
-yeccpars2_182_(__Stack0) ->
- [__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } , { defaultValue , __4 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_183_/1}).
--file("src/graphql_parser.yrl", 46).
-yeccpars2_183_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   [ __1 | __2 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_184_/1}).
--file("src/graphql_parser.yrl", 44).
-yeccpars2_184_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_185_/1}).
+-compile({inline,yeccpars2_149_/1}).
+-file("src/graphql_parser.yrl", 172).
+yeccpars2_149_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_150_/1}).
+-file("src/graphql_parser.yrl", 173).
+yeccpars2_150_(__Stack0) ->
+ [__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } , { defaultValue , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_152_/1}).
+-file("src/graphql_parser.yrl", 51).
+yeccpars2_152_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   __2
+  end | __Stack].
+
+-compile({inline,yeccpars2_154_/1}).
+-file("src/graphql_parser.yrl", 165).
+yeccpars2_154_(__Stack0) ->
+ [__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { arguments , __2 } , { type , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_155_/1}).
+-file("src/graphql_parser.yrl", 157).
+yeccpars2_155_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   __2
+  end | __Stack].
+
+-compile({inline,yeccpars2_156_/1}).
+-file("src/graphql_parser.yrl", 159).
+yeccpars2_156_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_157_/1}).
+-file("src/graphql_parser.yrl", 160).
+yeccpars2_157_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 | __2 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_160_/1}).
+-file("src/graphql_parser.yrl", 155).
+yeccpars2_160_(__Stack0) ->
+ [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'ObjectTypeDefinition' , [ { name , __2 } , { interfaces , __3 } , { fields , __5 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_161_/1}).
+-file("src/graphql_parser.yrl", 184).
+yeccpars2_161_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'ScalarTypeDefinition' , [ { name , __2 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_165_/1}).
+-file("src/graphql_parser.yrl", 176).
+yeccpars2_165_(__Stack0) ->
+ [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'InterfaceTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_169_/1}).
+-file("src/graphql_parser.yrl", 195).
+yeccpars2_169_(__Stack0) ->
+ [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'InputObjectTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_173_/1}).
+-file("src/graphql_parser.yrl", 39).
+yeccpars2_173_(__Stack0) ->
+ [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { selectionSet , __5 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_175_/1}).
+-file("src/graphql_parser.yrl", 40).
+yeccpars2_175_(__Stack0) ->
+ [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { directives , __5 } , { selectionSet , __6 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_176_/1}).
+-file("src/graphql_parser.yrl", 198).
+yeccpars2_176_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'TypeExtensionDefinition' , [ { definition , __2 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_180_/1}).
+-file("src/graphql_parser.yrl", 189).
+yeccpars2_180_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_182_/1}).
+-file("src/graphql_parser.yrl", 190).
+yeccpars2_182_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 | __2 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_183_/1}).
+-file("src/graphql_parser.yrl", 187).
+yeccpars2_183_(__Stack0) ->
+ [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'EnumTypeDefinition' , [ { name , __2 } , { values , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_184_/1}).
+-file("src/graphql_parser.yrl", 24).
+yeccpars2_184_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 | __2 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_187_/1}).
+-file("src/graphql_parser.yrl", 34).
+yeccpars2_187_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { selectionSet , __3 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_191_/1}).
+-file("src/graphql_parser.yrl", 45).
+yeccpars2_191_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_194_/1}).
+-file("src/graphql_parser.yrl", 47).
+yeccpars2_194_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_195_/1}).
+-file("src/graphql_parser.yrl", 48).
+yeccpars2_195_(__Stack0) ->
+ [__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } , { defaultValue , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_196_/1}).
+-file("src/graphql_parser.yrl", 46).
+yeccpars2_196_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 | __2 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_197_/1}).
+-file("src/graphql_parser.yrl", 44).
+yeccpars2_197_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   __2
+  end | __Stack].
+
+-compile({inline,yeccpars2_198_/1}).
 -file("src/graphql_parser.yrl", 36).
-yeccpars2_185_(__Stack0) ->
+yeccpars2_198_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_186_/1}).
+-compile({inline,yeccpars2_199_/1}).
 -file("src/graphql_parser.yrl", 35).
-yeccpars2_186_(__Stack0) ->
+yeccpars2_199_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { variableDefinitions , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_188_/1}).
+-compile({inline,yeccpars2_201_/1}).
 -file("src/graphql_parser.yrl", 37).
-yeccpars2_188_(__Stack0) ->
+yeccpars2_201_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { variableDefinitions , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
 
--file("src/graphql_parser.yrl", 206).
+-file("src/graphql_parser.yrl", 220).

--- a/src/graphql_parser.erl
+++ b/src/graphql_parser.erl
@@ -1,6 +1,6 @@
 -module(graphql_parser).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("src/graphql_parser.yrl", 204).
+-file("src/graphql_parser.yrl", 206).
 
 extract_atom({Value, _Line}) -> Value.
 extract_token({_Token, _Line, Value}) -> Value.
@@ -240,7 +240,7 @@ yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -270,9 +270,9 @@ yeccpars2(26=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %% yeccpars2(32=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_32(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(33=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(34=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(34=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_34(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(35=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(36=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -299,16 +299,16 @@ yeccpars2(46=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_46(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(47=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_47(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(48=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_48(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(49=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_49(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(50=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(48=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_48(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(49=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_49(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(50=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_50(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(51=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(52=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_52(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(52=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(53=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_53(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(54=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -317,30 +317,30 @@ yeccpars2(50=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(56=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_56(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(57=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(57=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_57(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(58=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_58(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(59=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_59(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(60=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(59=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(60=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_60(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(61=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_61(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(62=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_62(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(62=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(63=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_63(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(64=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_64(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(65=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_65(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(66=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(67=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(68=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_68(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(65=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_65(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(66=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(67=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_67(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(68=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(69=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_69(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(70=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -349,12 +349,12 @@ yeccpars2(66=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_71(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(72=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_72(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(73=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(74=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_74(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(73=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_73(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(74=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_74(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(75=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_75(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(76=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_76(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(77=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -363,36 +363,36 @@ yeccpars2(78=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_78(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(79=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_79(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(80=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_80(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(81=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_81(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(80=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_80(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(81=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_81(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(82=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_82(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(83=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_83(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(84=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(85=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_85(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(86=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_86(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(87=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_87(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(83=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_83(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(84=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_84(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(85=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_85(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(86=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_68(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(87=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_87(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(88=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_88(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(89=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_89(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(90=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_90(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(89=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_89(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(90=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_90(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(91=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_91(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(92=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_92(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(93=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_93(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(94=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_94(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(94=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_94(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(95=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_95(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(96=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -419,192 +419,196 @@ yeccpars2(92=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_106(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(107=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_107(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(108=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_108(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(108=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_108(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(109=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_109(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(110=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_110(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(110=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_110(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(111=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_111(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(112=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_112(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(113=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_113(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(114=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_114(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(114=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_114(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(115=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_115(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(116=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_116(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(117=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_117(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(118=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_118(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(119=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(118=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(119=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_119(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(120=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_120(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(121=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_121(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(121=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(122=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_122(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(123=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%% yeccpars2(123=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_123(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(124=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_124(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(125=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(124=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(126=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(125=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_125(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(126=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_126(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(127=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_127(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(128=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_128(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(129=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_129(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(129=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_129(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(130=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_130(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(131=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_131(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(132=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(133=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(132=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(133=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_133(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(134=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(134=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(135=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_135(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(136=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_136(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(137=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(137=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_137(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(138=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_138(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(139=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_139(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(140=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_140(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(140=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_140(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(141=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_141(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(142=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_142(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(143=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_143(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(142=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_142(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(143=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_143(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(144=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_144(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(145=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_145(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(146=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_146(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(147=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(148=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_148(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(149=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_149(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(150=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(146=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_146(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(147=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_147(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(148=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_148(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(149=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(150=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_150(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(151=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_151(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(152=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_68(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(153=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_153(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(154=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_154(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(154=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(155=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_155(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(156=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_156(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(157=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(157=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_157(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(158=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_158(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(159=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_159(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(160=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_160(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(161=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_161(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(162=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(161=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_161(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(162=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_162(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(163=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_163(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(164=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_164(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(165=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_165(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(166=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_166(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(167=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_167(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(168=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_168(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(169=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_169(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(170=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_170(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(171=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(172=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_172(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_171(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(172=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(173=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_53(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(174=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_174(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(175=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_175(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_57(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(176=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_176(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(177=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(177=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_177(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(178=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_178(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(179=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_179(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(179=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(180=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_180(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(181=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_181(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(182=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_182(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(182=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_182(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(183=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_183(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(184=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_184(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(184=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_184(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(185=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_51(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_185(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(186=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_186(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(187=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(188=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_188(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_53(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(188=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_188(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(189=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_189(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(190=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_190(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_57(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(190=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_190(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(191=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_191(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(192=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(192=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_192(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(193=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_193(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(194=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_194(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(194=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(195=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_195(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(196=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_196(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(196=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_196(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(197=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_197(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(198=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_198(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(198=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_198(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(199=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_55(S, Cat, Ss, Stack, T, Ts, Tzr);
+%%  yeccpars2_199(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(200=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_200(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(201=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_57(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(202=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_202(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -649,34 +653,10 @@ yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccpars2_5(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'TypeDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_6(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, extend, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, fragment, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, implements, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, input, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, interface, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, mutation, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, null, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, query, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_6(S, on, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, type, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_6(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_7(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Definition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
@@ -738,7 +718,34 @@ yeccpars2_17(S, type, Ss, Stack, T, Ts, Tzr) ->
 yeccpars2_17(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_18: see yeccpars2_6
+yeccpars2_18(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 %% yeccpars2_19: see yeccpars2_6
 
@@ -759,61 +766,65 @@ yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %% yeccpars2_25: see yeccpars2_6
 
 yeccpars2_26(S, '...', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 34, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
 yeccpars2_26(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_27(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 114, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 116, Ss, Stack, T, Ts, Tzr);
 yeccpars2_27(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_28(S, '...', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 34, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, on, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_28(S, union, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_28(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_28(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
 yeccpars2_28(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_28_(Stack),
  'yeccgoto_\'Selections\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_29(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 60, Ss, Stack, T, Ts, Tzr);
-yeccpars2_29(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 108, Ss, Stack, T, Ts, Tzr);
-yeccpars2_29(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_29(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_29_(Stack),
- 'yeccgoto_\'Field\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
+yeccpars2_30(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 62, Ss, Stack, T, Ts, Tzr);
+yeccpars2_30(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 110, Ss, Stack, T, Ts, Tzr);
+yeccpars2_30(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
+yeccpars2_30(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_30(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Selection\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+ NewStack = yeccpars2_30_(Stack),
+ 'yeccgoto_\'Field\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Selection\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
@@ -821,52 +832,51 @@ yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Selection\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-%% yeccpars2_33: see yeccpars2_6
+yeccpars2_33(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'Selection\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_34(S, on, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 50, Ss, Stack, T, Ts, Tzr);
-yeccpars2_34(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+%% yeccpars2_34: see yeccpars2_6
 
-yeccpars2_35(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_35_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+yeccpars2_35(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 52, Ss, Stack, T, Ts, Tzr);
+yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_36(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_36_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_37(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_37_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_38(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_38_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_39(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_39_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_40_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_41_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_42_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_43(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_43_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_44(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_44_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_45(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_45_(Stack),
@@ -874,188 +884,194 @@ yeccpars2_45(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 yeccpars2_46(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_46_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_47(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_47_(Stack),
- 'yeccgoto_\'Name\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_48(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_48_(Stack),
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_49_(Stack),
+ 'yeccgoto_\'NameWithoutOn\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_50(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'FragmentName\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_49(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_49(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_51(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
+yeccpars2_51(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_49_(Stack),
+ NewStack = yeccpars2_51_(Stack),
  'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_50: see yeccpars2_6
+%% yeccpars2_52: see yeccpars2_6
 
-yeccpars2_51(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_53(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
+yeccpars2_53(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_51(_, _, _, _, T, _, _) ->
+yeccpars2_53(_, _, _, _, T, _, _) ->
  yeccerror(T).
-
-yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'TypeCondition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_53_(Stack),
- 'yeccgoto_\'NamedType\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'TypeCondition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_55_(Stack),
+ 'yeccgoto_\'NamedType\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_56(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_54_(Stack),
+ NewStack = yeccpars2_56_(Stack),
  'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_55(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_57(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_55(_, _, _, _, T, _, _) ->
+yeccpars2_57(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_56(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_56(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_56_(Stack),
+yeccpars2_58(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
+yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_58_(Stack),
  'yeccgoto_\'Directives\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_57: see yeccpars2_6
+%% yeccpars2_59: see yeccpars2_6
 
-yeccpars2_58(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 60, Ss, Stack, T, Ts, Tzr);
-yeccpars2_58(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_60(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 62, Ss, Stack, T, Ts, Tzr);
+yeccpars2_60(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_58_(Stack),
+ NewStack = yeccpars2_60_(Stack),
  'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_61(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_59_(Stack),
+ NewStack = yeccpars2_61_(Stack),
  'yeccgoto_\'Directive\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_60: see yeccpars2_6
+%% yeccpars2_62: see yeccpars2_6
 
-yeccpars2_61(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 66, Ss, Stack, T, Ts, Tzr);
-yeccpars2_61(_, _, _, _, T, _, _) ->
+yeccpars2_63(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 68, Ss, Stack, T, Ts, Tzr);
+yeccpars2_63(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_62(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 65, Ss, Stack, T, Ts, Tzr);
-yeccpars2_62(_, _, _, _, T, _, _) ->
+yeccpars2_64(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 67, Ss, Stack, T, Ts, Tzr);
+yeccpars2_64(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_63(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, on, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(S, union, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_65(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_63(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_63_(Stack),
+yeccpars2_65(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_65(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
+yeccpars2_65(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_65_(Stack),
  'yeccgoto_\'ArgumentList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_64(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_66(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_64_(Stack),
+ NewStack = yeccpars2_66_(Stack),
  'yeccgoto_\'ArgumentList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_65(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_65_(Stack),
+ NewStack = yeccpars2_67_(Stack),
  'yeccgoto_\'Arguments\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_66(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
-yeccpars2_66(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
-yeccpars2_66(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_68(S, '$', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
-yeccpars2_66(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_68(S, '[', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
-yeccpars2_66(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_68(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
-yeccpars2_66(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_68(S, float_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
-yeccpars2_66(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_68(S, int_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
-yeccpars2_66(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_68_(Stack),
- 'yeccgoto_\'Argument\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_68(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_68(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
+yeccpars2_68(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 81, Ss, Stack, T, Ts, Tzr);
+yeccpars2_68(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_69_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'EnumValue\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_70_(Stack),
+ 'yeccgoto_\'Argument\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_71_(Stack),
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_72_(Stack),
+ 'yeccgoto_\'EnumValue\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_73_(Stack),
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_73: see yeccpars2_6
+yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_74_(Stack),
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_74(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 90, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+%% yeccpars2_75: see yeccpars2_6
+
+yeccpars2_76(S, '$', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_76(S, '[', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_76(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 92, Ss, Stack, T, Ts, Tzr);
+yeccpars2_76(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_76(S, float_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_76(S, int_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
-yeccpars2_74(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_75(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_75_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
-
-yeccpars2_76(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_76_(Stack),
- 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+yeccpars2_76(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_76(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
+yeccpars2_76(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 81, Ss, Stack, T, Ts, Tzr);
+yeccpars2_76(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_77(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_77_(Stack),
@@ -1065,778 +1081,802 @@ yeccpars2_78(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_78_(Stack),
  'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_79(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 83, Ss, Stack, T, Ts, Tzr);
-yeccpars2_79(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_79(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_79_(Stack),
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_80(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 87, Ss, Stack, T, Ts, Tzr);
-yeccpars2_80(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_80(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_80_(Stack),
+ 'yeccgoto_\'Value\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_81(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, extend, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, fragment, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, implements, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, input, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, interface, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, mutation, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, null, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, query, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_81(S, on, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, type, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_81(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_81_(Stack),
- 'yeccgoto_\'ObjectFields\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+yeccpars2_81(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 85, Ss, Stack, T, Ts, Tzr);
+yeccpars2_81(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_82(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 84, Ss, Stack, T, Ts, Tzr);
+yeccpars2_82(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 89, Ss, Stack, T, Ts, Tzr);
 yeccpars2_82(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
+yeccpars2_83(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_83(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
 yeccpars2_83(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_83_(Stack),
- 'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ObjectFields\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_84: see yeccpars2_66
+yeccpars2_84(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 86, Ss, Stack, T, Ts, Tzr);
+yeccpars2_84(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_85(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_85_(Stack),
- 'yeccgoto_\'ObjectField\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_86_(Stack),
- 'yeccgoto_\'ObjectFields\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_85_(Stack),
+ 'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_86: see yeccpars2_68
 
 yeccpars2_87(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_87_(Stack),
+ 'yeccgoto_\'ObjectField\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_88(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_88_(Stack),
+ 'yeccgoto_\'ObjectFields\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_89(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_89_(Stack),
  'yeccgoto_\'ObjectValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_88(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 92, Ss, Stack, T, Ts, Tzr);
-yeccpars2_88(_, _, _, _, T, _, _) ->
+yeccpars2_90(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 94, Ss, Stack, T, Ts, Tzr);
+yeccpars2_90(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_89(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 74, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_91(S, '$', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, extend, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, float_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_91(S, '[', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 76, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, fragment, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, implements, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, input, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, int_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_91(S, boolean_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 77, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, interface, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, mutation, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, null, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, query, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, scalar, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_91(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, float_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 78, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, type, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_91(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, int_value, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 79, Ss, Stack, T, Ts, Tzr);
-yeccpars2_89(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_89_(Stack),
+yeccpars2_91(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, string_value, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 80, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 81, Ss, Stack, T, Ts, Tzr);
+yeccpars2_91(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_91_(Stack),
  'yeccgoto_\'Values\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_90(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_90_(Stack),
- 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_91(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_91_(Stack),
- 'yeccgoto_\'Values\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
 yeccpars2_92(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_92_(Stack),
  'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_93_(Stack),
- 'yeccgoto_\'Variable\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Values\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_94(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_94_(Stack),
- 'yeccgoto_\'Directives\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ListValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_95_(Stack),
- 'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Variable\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_96_(Stack),
- 'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_97(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 60, Ss, Stack, T, Ts, Tzr);
-yeccpars2_97(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_97(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
+ NewStack = yeccpars2_96_(Stack),
+ 'yeccgoto_\'Directives\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_97_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'InlineFragment\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_98(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_98_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'FragmentSpread\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_99(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 62, Ss, Stack, T, Ts, Tzr);
+yeccpars2_99(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
 yeccpars2_99(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_99(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_99_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_100(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_100(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_100(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_100_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_101(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_101(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_101_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_102(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
 yeccpars2_102(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_102(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_102_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_103(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_103_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_104(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_104(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_104_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_105_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_106(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_106(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_106_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_107(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_107(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_107(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_107_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_108(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_108(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_108_(Stack),
- 'yeccgoto_\'Alias\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_109(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
+yeccpars2_109(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_109(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_109_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_110(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_110(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_110_(Stack),
- 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Alias\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_111(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_111_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+yeccpars2_112(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
 yeccpars2_112(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_112_(Stack),
  'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_113_(Stack),
- 'yeccgoto_\'Selections\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_114(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_114_(Stack),
+ 'yeccgoto_\'Field\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_115(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_115_(Stack),
+ 'yeccgoto_\'Selections\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_116(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_116_(Stack),
  'yeccgoto_\'SelectionSet\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_115(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 116, Ss, Stack, T, Ts, Tzr);
-yeccpars2_115(_, _, _, _, T, _, _) ->
+yeccpars2_117(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 118, Ss, Stack, T, Ts, Tzr);
+yeccpars2_117(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_116: see yeccpars2_6
+%% yeccpars2_118: see yeccpars2_6
 
-yeccpars2_117(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_119(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_117_(Stack),
+ NewStack = yeccpars2_119_(Stack),
  'yeccgoto_\'UnionTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_118(S, '|', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 119, Ss, Stack, T, Ts, Tzr);
-yeccpars2_118(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_118_(Stack),
+yeccpars2_120(S, '|', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 121, Ss, Stack, T, Ts, Tzr);
+yeccpars2_120(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_120_(Stack),
  'yeccgoto_\'UnionMembers\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_119: see yeccpars2_6
+%% yeccpars2_121: see yeccpars2_6
 
-yeccpars2_120(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_120_(Stack),
+ NewStack = yeccpars2_122_(Stack),
  'yeccgoto_\'UnionMembers\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_121(S, implements, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 123, Ss, Stack, T, Ts, Tzr);
-yeccpars2_121(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 124, Ss, Stack, T, Ts, Tzr);
-yeccpars2_121(_, _, _, _, T, _, _) ->
+yeccpars2_123(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 125, Ss, Stack, T, Ts, Tzr);
+yeccpars2_123(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 126, Ss, Stack, T, Ts, Tzr);
+yeccpars2_123(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_122(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 157, Ss, Stack, T, Ts, Tzr);
-yeccpars2_122(_, _, _, _, T, _, _) ->
+yeccpars2_124(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 159, Ss, Stack, T, Ts, Tzr);
+yeccpars2_124(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_123: see yeccpars2_6
+%% yeccpars2_125: see yeccpars2_6
 
-%% yeccpars2_124: see yeccpars2_6
+%% yeccpars2_126: see yeccpars2_6
 
-yeccpars2_125(S, '(', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_127(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 133, Ss, Stack, T, Ts, Tzr);
+yeccpars2_127(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 134, Ss, Stack, T, Ts, Tzr);
+yeccpars2_127(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_128(S, '}', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 131, Ss, Stack, T, Ts, Tzr);
-yeccpars2_125(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 132, Ss, Stack, T, Ts, Tzr);
-yeccpars2_125(_, _, _, _, T, _, _) ->
+yeccpars2_128(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_126(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 129, Ss, Stack, T, Ts, Tzr);
-yeccpars2_126(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_127(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, on, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(S, union, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_129(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_127(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_127_(Stack),
+yeccpars2_129(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_129(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
+yeccpars2_129(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_129_(Stack),
  'yeccgoto_\'FieldDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_128(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_130(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_128_(Stack),
+ NewStack = yeccpars2_130_(Stack),
  'yeccgoto_\'FieldDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_129(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_131(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_129_(Stack),
+ NewStack = yeccpars2_131_(Stack),
  'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_130(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 152, Ss, Stack, T, Ts, Tzr);
-yeccpars2_130(_, _, _, _, T, _, _) ->
+yeccpars2_132(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 154, Ss, Stack, T, Ts, Tzr);
+yeccpars2_132(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_131: see yeccpars2_6
+%% yeccpars2_133: see yeccpars2_6
 
-yeccpars2_132(S, '[', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 137, Ss, Stack, T, Ts, Tzr);
-yeccpars2_132(S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccpars2_134(S, '[', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 139, Ss, Stack, T, Ts, Tzr);
+yeccpars2_134(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_134(S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_133(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_133_(Stack),
+ NewStack = yeccpars2_135_(Stack),
  'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_135(S, '!', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 141, Ss, Stack, T, Ts, Tzr);
-yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_136(S, '!', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 140, Ss, Stack, T, Ts, Tzr);
 yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-%% yeccpars2_137: see yeccpars2_132
+yeccpars2_137(S, '!', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 143, Ss, Stack, T, Ts, Tzr);
+yeccpars2_137(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
-yeccpars2_138(S, ']', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 139, Ss, Stack, T, Ts, Tzr);
-yeccpars2_138(_, _, _, _, T, _, _) ->
+yeccpars2_138(S, '!', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 142, Ss, Stack, T, Ts, Tzr);
+yeccpars2_138(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ 'yeccgoto_\'Type\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+
+%% yeccpars2_139: see yeccpars2_134
+
+yeccpars2_140(S, ']', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 141, Ss, Stack, T, Ts, Tzr);
+yeccpars2_140(_, _, _, _, T, _, _) ->
  yeccerror(T).
-
-yeccpars2_139(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_139_(Stack),
- 'yeccgoto_\'ListType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_140(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_140_(Stack),
- 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_141(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_141_(Stack),
+ 'yeccgoto_\'ListType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_142(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_142_(Stack),
  'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_142(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 147, Ss, Stack, T, Ts, Tzr);
-yeccpars2_142(_, _, _, _, T, _, _) ->
+yeccpars2_143(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_143_(Stack),
+ 'yeccgoto_\'NonNullType\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_144(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 149, Ss, Stack, T, Ts, Tzr);
+yeccpars2_144(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_143(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 146, Ss, Stack, T, Ts, Tzr);
-yeccpars2_143(_, _, _, _, T, _, _) ->
+yeccpars2_145(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 148, Ss, Stack, T, Ts, Tzr);
+yeccpars2_145(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_144(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, extend, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, on, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(S, union, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_146(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_144(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_144_(Stack),
+yeccpars2_146(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_146(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
+yeccpars2_146(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_146_(Stack),
  'yeccgoto_\'InputValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_145(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_147(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_145_(Stack),
+ NewStack = yeccpars2_147_(Stack),
  'yeccgoto_\'InputValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_146(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_146_(Stack),
- 'yeccgoto_\'ArgumentsDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-%% yeccpars2_147: see yeccpars2_132
-
-yeccpars2_148(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 150, Ss, Stack, T, Ts, Tzr);
 yeccpars2_148(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
  NewStack = yeccpars2_148_(Stack),
- 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'ArgumentsDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_149(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_149_(Stack),
- 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_149: see yeccpars2_134
 
-%% yeccpars2_150: see yeccpars2_66
+yeccpars2_150(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 152, Ss, Stack, T, Ts, Tzr);
+yeccpars2_150(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_150_(Stack),
+ 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_151(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_151_(Stack),
- 'yeccgoto_\'DefaultValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'InputValueDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_152: see yeccpars2_132
+%% yeccpars2_152: see yeccpars2_68
 
 yeccpars2_153(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_153_(Stack),
- 'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_154_(Stack),
- 'yeccgoto_\'ImplementsInterfaces\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_153_(Stack),
+ 'yeccgoto_\'DefaultValue\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_155(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, extend, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, fragment, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, implements, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, input, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, interface, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, mutation, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, name, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, null, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, query, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, scalar, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, type, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_155(S, union, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2_154: see yeccpars2_134
+
 yeccpars2_155(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_155_(Stack),
- 'yeccgoto_\'NamedTypeList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'FieldDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_156(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_156_(Stack),
+ 'yeccgoto_\'ImplementsInterfaces\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_157(S, enum, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, extend, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, implements, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, input, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, interface, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, name, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, null, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, query, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
+yeccpars2_157(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_157_(Stack),
+ 'yeccgoto_\'NamedTypeList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_158(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_158_(Stack),
  'yeccgoto_\'NamedTypeList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_157: see yeccpars2_6
+%% yeccpars2_159: see yeccpars2_6
 
-yeccpars2_158(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 159, Ss, Stack, T, Ts, Tzr);
-yeccpars2_158(_, _, _, _, T, _, _) ->
+yeccpars2_160(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 161, Ss, Stack, T, Ts, Tzr);
+yeccpars2_160(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_159(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_161(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_159_(Stack),
+ NewStack = yeccpars2_161_(Stack),
  'yeccgoto_\'ObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_160(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_162(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_160_(Stack),
+ NewStack = yeccpars2_162_(Stack),
  'yeccgoto_\'ScalarTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_161(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 162, Ss, Stack, T, Ts, Tzr);
-yeccpars2_161(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-%% yeccpars2_162: see yeccpars2_6
-
-yeccpars2_163(S, '}', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_163(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 164, Ss, Stack, T, Ts, Tzr);
 yeccpars2_163(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_164(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_164_(Stack),
- 'yeccgoto_\'InterfaceTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_164: see yeccpars2_6
 
-yeccpars2_165(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_165(S, '}', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 166, Ss, Stack, T, Ts, Tzr);
 yeccpars2_165(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_166: see yeccpars2_6
+yeccpars2_166(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_166_(Stack),
+ 'yeccgoto_\'InterfaceTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_167(S, '}', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_167(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 168, Ss, Stack, T, Ts, Tzr);
 yeccpars2_167(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_168(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_168_(Stack),
- 'yeccgoto_\'InputObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_168: see yeccpars2_6
 
-yeccpars2_169(S, on, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_169(S, '}', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 170, Ss, Stack, T, Ts, Tzr);
 yeccpars2_169(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_170: see yeccpars2_6
-
-%% yeccpars2_171: see yeccpars2_51
-
-yeccpars2_172(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_170(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_172_(Stack),
- 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ NewStack = yeccpars2_170_(Stack),
+ 'yeccgoto_\'InputObjectTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_173: see yeccpars2_55
+yeccpars2_171(S, on, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 172, Ss, Stack, T, Ts, Tzr);
+yeccpars2_171(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+%% yeccpars2_172: see yeccpars2_6
+
+%% yeccpars2_173: see yeccpars2_53
 
 yeccpars2_174(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_|Nss] = Ss,
+ [_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_174_(Stack),
  'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_175(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%% yeccpars2_175: see yeccpars2_57
+
+yeccpars2_176(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_176_(Stack),
+ 'yeccgoto_\'FragmentDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_177(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_175_(Stack),
+ NewStack = yeccpars2_177_(Stack),
  'yeccgoto_\'TypeExtensionDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_176(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 177, Ss, Stack, T, Ts, Tzr);
-yeccpars2_176(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-%% yeccpars2_177: see yeccpars2_6
-
-yeccpars2_178(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 182, Ss, Stack, T, Ts, Tzr);
+yeccpars2_178(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 179, Ss, Stack, T, Ts, Tzr);
 yeccpars2_178(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_179(S, enum, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, extend, Ss, Stack, T, Ts, Tzr) ->
+%% yeccpars2_179: see yeccpars2_6
+
+yeccpars2_180(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 184, Ss, Stack, T, Ts, Tzr);
+yeccpars2_180(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_181(S, enum, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, fragment, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, extend, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, implements, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, fragment, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, input, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, implements, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, interface, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, input, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 40, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, mutation, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, interface, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, name, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, mutation, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 42, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, null, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, name, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, query, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, null, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 44, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, scalar, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, on, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, type, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, query, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 46, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(S, union, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_181(S, scalar, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 47, Ss, Stack, T, Ts, Tzr);
-yeccpars2_179(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_179_(Stack),
+yeccpars2_181(S, type, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 48, Ss, Stack, T, Ts, Tzr);
+yeccpars2_181(S, union, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 49, Ss, Stack, T, Ts, Tzr);
+yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_181_(Stack),
  'yeccgoto_\'EnumValueDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- 'yeccgoto_\'EnumValueDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
-
-yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
- NewStack = yeccpars2_181_(Stack),
- 'yeccgoto_\'EnumValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
 yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_182_(Stack),
- 'yeccgoto_\'EnumTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'EnumValueDefinition\''(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_183_(Stack),
+ 'yeccgoto_\'EnumValueDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_184(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_184_(Stack),
+ 'yeccgoto_\'EnumTypeDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_185(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_185_(Stack),
  'yeccgoto_\'Definitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_184(S, '(', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 188, Ss, Stack, T, Ts, Tzr);
-yeccpars2_184(S, '@', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 57, Ss, Stack, T, Ts, Tzr);
-yeccpars2_184(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_186(S, '(', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 190, Ss, Stack, T, Ts, Tzr);
+yeccpars2_186(S, '@', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 59, Ss, Stack, T, Ts, Tzr);
+yeccpars2_186(S, '{', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_184(_, _, _, _, T, _, _) ->
+yeccpars2_186(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_185: see yeccpars2_51
+%% yeccpars2_187: see yeccpars2_53
 
-yeccpars2_186(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
- NewStack = yeccpars2_186_(Stack),
+ NewStack = yeccpars2_188_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_187: see yeccpars2_55
-
-yeccpars2_188(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
-yeccpars2_188(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_189(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 196, Ss, Stack, T, Ts, Tzr);
-yeccpars2_189(_, _, _, _, T, _, _) ->
- yeccerror(T).
+%% yeccpars2_189: see yeccpars2_57
 
 yeccpars2_190(S, '$', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 73, Ss, Stack, T, Ts, Tzr);
-yeccpars2_190(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_190_(Stack),
- 'yeccgoto_\'VariableDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
+yeccpars2_190(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_191(S, ':', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 192, Ss, Stack, T, Ts, Tzr);
+yeccpars2_191(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 198, Ss, Stack, T, Ts, Tzr);
 yeccpars2_191(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_192: see yeccpars2_132
+yeccpars2_192(S, '$', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 75, Ss, Stack, T, Ts, Tzr);
+yeccpars2_192(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_192_(Stack),
+ 'yeccgoto_\'VariableDefinitionList\''(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
-yeccpars2_193(S, '=', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 150, Ss, Stack, T, Ts, Tzr);
-yeccpars2_193(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_193_(Stack),
- 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+yeccpars2_193(S, ':', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 194, Ss, Stack, T, Ts, Tzr);
+yeccpars2_193(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_194(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
- NewStack = yeccpars2_194_(Stack),
- 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_194: see yeccpars2_134
 
+yeccpars2_195(S, '=', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 152, Ss, Stack, T, Ts, Tzr);
 yeccpars2_195(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_195_(Stack),
- 'yeccgoto_\'VariableDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_196(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_196_(Stack),
- 'yeccgoto_\'VariableDefinitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'VariableDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_197(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_|Nss] = Ss,
  NewStack = yeccpars2_197_(Stack),
- 'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ 'yeccgoto_\'VariableDefinitionList\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_198(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_198_(Stack),
+ 'yeccgoto_\'VariableDefinitions\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_199(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_199_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_199: see yeccpars2_55
-
 yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_|Nss] = Ss,
+ [_,_,_|Nss] = Ss,
  NewStack = yeccpars2_200_(Stack),
  'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
+%% yeccpars2_201: see yeccpars2_57
+
+yeccpars2_202(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_202_(Stack),
+ 'yeccgoto_\'OperationDefinition\''(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
 'yeccgoto_\'Alias\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(33, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_6(34, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Alias\''(28, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_6(33, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_6(34, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Argument\''(60, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_63(63, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Argument\''(63, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_63(63, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Argument\''(62, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_65(65, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Argument\''(65, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_65(65, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ArgumentList\''(60, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_62(62, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ArgumentList\''(63=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_64(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ArgumentList\''(62, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_64(64, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ArgumentList\''(65=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_66(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Arguments\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_107(107, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Arguments\''(58=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_59(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Arguments\''(97, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_100(100, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Arguments\''(30, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_109(109, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Arguments\''(60=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_61(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Arguments\''(99, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_102(102, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ArgumentsDefinition\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_130(130, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ArgumentsDefinition\''(127, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_132(132, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'DefaultValue\''(148=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_149(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'DefaultValue\''(193=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_194(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'DefaultValue\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_151(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'DefaultValue\''(195=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_196(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Definition\''(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_15(15, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1846,49 +1886,49 @@ yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'Definitions\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Definitions\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_185(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Directive\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(49, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(30, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Directive\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(56, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(97, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(100, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(107, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(171, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(184, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directive\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_56(56, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(53, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(58, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(99, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(102, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(109, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(173, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(186, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directive\''(187, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Directives\''(29, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_106(106, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(49=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'Directives\''(30, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_108(108, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_98(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(53, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(57, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(58=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_96(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(51, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(55, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(56=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_94(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(97, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_99(99, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(100, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_102(102, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(107, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_110(110, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(171, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(173, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(184, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(187, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Directives\''(185, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_55(199, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Directives\''(99, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_101(101, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(102, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_104(104, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(109, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_112(112, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(173, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(175, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(186, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(189, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Directives\''(187, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_57(201, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Document\''(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_13(13, Cat, Ss, Stack, T, Ts, Tzr).
@@ -1898,53 +1938,53 @@ yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'EnumTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_12(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValue\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValue\''(177=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(68=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(76=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(86=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(91=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_74(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'EnumValue\''(179=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_180(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValue\''(181=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_182(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValueDefinition\''(177, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_179(179, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'EnumValueDefinition\''(179, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_179(179, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_181(181, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValueDefinition\''(181, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_181(181, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'EnumValueDefinitionList\''(177, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_178(178, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'EnumValueDefinitionList\''(179=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_181(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'EnumValueDefinitionList\''(179, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_180(180, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'EnumValueDefinitionList\''(181=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_183(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Field\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_33(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Field\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_33(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'FieldDefinition\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(127, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(157, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinition\''(162, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'FieldDefinition\''(126, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_129(129, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(129, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_129(129, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(159, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_129(129, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinition\''(164, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_129(129, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'FieldDefinitionList\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_126(126, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(127=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_128(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(157, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_158(158, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FieldDefinitionList\''(162, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_163(163, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'FieldDefinitionList\''(126, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_128(128, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(129=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_130(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(159, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_160(160, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FieldDefinitionList\''(164, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_165(165, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -1952,222 +1992,305 @@ yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentName\''(18, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_169(169, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'FragmentName\''(34, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_49(49, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_171(171, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'FragmentName\''(35, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_51(51, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'FragmentSpread\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'FragmentSpread\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ImplementsInterfaces\''(121, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_122(122, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ImplementsInterfaces\''(123, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_124(124, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'InlineFragment\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_30(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'InlineFragment\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_30(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'InputObjectTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'InputObjectTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'InputValueDefinition\''(131, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinition\''(144, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinition\''(166, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'InputValueDefinition\''(133, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_146(146, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinition\''(146, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_146(146, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinition\''(168, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_146(146, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'InputValueDefinitionList\''(131, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_143(143, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinitionList\''(144=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_145(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'InputValueDefinitionList\''(166, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_167(167, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'InputValueDefinitionList\''(133, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_145(145, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinitionList\''(146=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_147(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'InputValueDefinitionList\''(168, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_169(169, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'InterfaceTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'InterfaceTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ListType\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(137, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(147, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(152, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListType\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_136(136, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ListType\''(134, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_138(138, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(139, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_138(138, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(149, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_138(138, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(154, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_138(138, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListType\''(194, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_138(138, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ListValue\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ListValue\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ListValue\''(68=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(76=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(86=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(91=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ListValue\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_73(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Name\''(6, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_184(184, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_186(186, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(16, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_176(176, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(18=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_48(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_178(178, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(19, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_165(165, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_167(167, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(20, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_161(161, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_163(163, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(23=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_160(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_162(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(24, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_121(121, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_123(123, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(25, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_115(115, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_117(117, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_29(29, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_30(30, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(28, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_29(29, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(33, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_97(97, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_48(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(50=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(57, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_58(58, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(60, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_61(61, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(63, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_61(61, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(73=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(79, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_30(30, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(34, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_99(99, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(52=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(59, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_60(60, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(62, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_63(63, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(65, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_63(63, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(68=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(76=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(81, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(116=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(119=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(123=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(124, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(127, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(131, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_142(142, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(132=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(137=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(144, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_142(142, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(147=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_84(84, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(83, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_84(84, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(86=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(91=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(118=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(121=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(125=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(126, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(129, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(133, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(134=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(139=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(146, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(149=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(155=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(157, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(162, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_125(125, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(166, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_142(142, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(170=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(177=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(154=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(157=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(159, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(164, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_127(127, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(168, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_144(144, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(172=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Name\''(179=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Name\''(192=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_53(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(181=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_72(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Name\''(194=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_55(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'NamedType\''(50=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(116, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_118(118, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(119, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_118(118, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(123, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_155(155, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(132, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(137, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(147, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(152, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(155, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_155(155, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(170=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_52(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedType\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_135(135, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'NameWithoutOn\''(6=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(16=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(18=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_50(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(19=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(20=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(23=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(24=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(25=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(35=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_50(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(52=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(59=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(62=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(65=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(68=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(75=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(76=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(81=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(83=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(86=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(91=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(118=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(121=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(125=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(126=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(129=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(133=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(134=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(139=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(146=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(149=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(154=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(157=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(159=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(164=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(168=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(172=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(179=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(181=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NameWithoutOn\''(194=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'NamedTypeList\''(123=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_154(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NamedTypeList\''(155=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_156(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'NamedType\''(52=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(118, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_120(120, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(121, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_120(120, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(125, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_157(157, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(134, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(139, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(149, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(154, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(157, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_157(157, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(172=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedType\''(194, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_137(137, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'NonNullType\''(132=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(137=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(147=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'NonNullType\''(192=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_134(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'NamedTypeList\''(125=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_156(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NamedTypeList\''(157=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_158(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectField\''(79, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_81(81, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(134=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(139=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(149=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(154=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'NonNullType\''(194=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_136(_S, Cat, Ss, Stack, T, Ts, Tzr).
+
 'yeccgoto_\'ObjectField\''(81, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_81(81, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_83(83, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectField\''(83, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_83(83, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectFields\''(79, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_80(80, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectFields\''(81=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_86(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ObjectFields\''(81, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_82(82, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectFields\''(83=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_88(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'ObjectTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'ObjectTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'ObjectTypeDefinition\''(17=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_175(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_177(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'ObjectValue\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'ObjectValue\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'ObjectValue\''(68=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(76=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(86=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(91=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'ObjectValue\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_71(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'OperationDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_7(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -2193,59 +2316,59 @@ yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_4(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(29=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(51=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_54(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(55=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_95(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(97=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_98(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(30=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_107(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(53=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_56(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(57=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_97(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(99=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_104(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(100=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_101(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_100(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(101=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_106(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(102=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_103(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(106=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_112(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(107=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_109(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(110=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+'yeccgoto_\'SelectionSet\''(104=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_105(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(108=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_114(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(109=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_111(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(171=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_172(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(112=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(173=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_174(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(184=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_186(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(185=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_198(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(175=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_176(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(186=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_188(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'SelectionSet\''(187=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_197(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'SelectionSet\''(199=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(189=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_199(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'SelectionSet\''(201=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_202(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'Selections\''(26, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_27(27, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Selections\''(28=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_113(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_115(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Type\''(132=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_133(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(137, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_138(138, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(147, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_148(148, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_153(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Type\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_193(193, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Type\''(134=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_135(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(139, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_140(140, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(149, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_150(150, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(154=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_155(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Type\''(194, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_195(195, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'TypeCondition\''(50, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_51(51, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'TypeCondition\''(170, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_51(171, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'TypeCondition\''(52, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(53, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'TypeCondition\''(172, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(173, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'TypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(_S, Cat, Ss, Stack, T, Ts, Tzr);
@@ -2257,59 +2380,59 @@ yeccpars2_200(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 'yeccgoto_\'TypeExtensionDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_2(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'UnionMembers\''(116=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_117(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'UnionMembers\''(119=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_120(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'UnionMembers\''(118=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_119(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'UnionMembers\''(121=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_122(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 'yeccgoto_\'UnionTypeDefinition\''(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'UnionTypeDefinition\''(15=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Value\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_68(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(74, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_89(89, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_85(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(89, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_89(89, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Value\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_151(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Value\''(68=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_70(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(76, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_91(91, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(86=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_87(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(91, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_91(91, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Value\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_153(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Values\''(74, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_88(88, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Values\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_91(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'Values\''(76, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_90(90, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Values\''(91=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_93(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'Variable\''(66=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(74=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(84=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(89=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(150=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_67(_S, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'Variable\''(188, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_191(191, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(68=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(76=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(86=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(91=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(152=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_69(_S, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'Variable\''(190, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_191(191, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_193(193, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'Variable\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_193(193, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinition\''(188, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_190(190, Cat, Ss, Stack, T, Ts, Tzr);
 'yeccgoto_\'VariableDefinition\''(190, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_190(190, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_192(192, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'VariableDefinition\''(192, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_192(192, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinitionList\''(188, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_189(189, Cat, Ss, Stack, T, Ts, Tzr);
-'yeccgoto_\'VariableDefinitionList\''(190=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_195(_S, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'VariableDefinitionList\''(190, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_191(191, Cat, Ss, Stack, T, Ts, Tzr);
+'yeccgoto_\'VariableDefinitionList\''(192=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_197(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
-'yeccgoto_\'VariableDefinitions\''(184, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_51(185, Cat, Ss, Stack, T, Ts, Tzr).
+'yeccgoto_\'VariableDefinitions\''(186, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_53(187, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_4_/1}).
 -file("src/graphql_parser.yrl", 33).
@@ -2359,24 +2482,16 @@ yeccpars2_28_(__Stack0) ->
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_29_/1}).
+-compile({inline,yeccpars2_30_/1}).
 -file("src/graphql_parser.yrl", 78).
-yeccpars2_29_(__Stack0) ->
+yeccpars2_30_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , { name , __1 } )
   end | __Stack].
 
--compile({inline,yeccpars2_35_/1}).
--file("src/graphql_parser.yrl", 117).
-yeccpars2_35_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   extract_keyword ( __1 )
-  end | __Stack].
-
 -compile({inline,yeccpars2_36_/1}).
--file("src/graphql_parser.yrl", 119).
+-file("src/graphql_parser.yrl", 116).
 yeccpars2_36_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2384,7 +2499,7 @@ yeccpars2_36_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_37_/1}).
--file("src/graphql_parser.yrl", 110).
+-file("src/graphql_parser.yrl", 118).
 yeccpars2_37_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2392,7 +2507,7 @@ yeccpars2_37_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_38_/1}).
--file("src/graphql_parser.yrl", 113).
+-file("src/graphql_parser.yrl", 110).
 yeccpars2_38_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2400,7 +2515,7 @@ yeccpars2_38_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_39_/1}).
--file("src/graphql_parser.yrl", 118).
+-file("src/graphql_parser.yrl", 112).
 yeccpars2_39_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2408,7 +2523,7 @@ yeccpars2_39_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_40_/1}).
--file("src/graphql_parser.yrl", 114).
+-file("src/graphql_parser.yrl", 117).
 yeccpars2_40_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2416,7 +2531,7 @@ yeccpars2_40_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_41_/1}).
--file("src/graphql_parser.yrl", 109).
+-file("src/graphql_parser.yrl", 113).
 yeccpars2_41_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2424,23 +2539,23 @@ yeccpars2_41_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_42_/1}).
--file("src/graphql_parser.yrl", 107).
+-file("src/graphql_parser.yrl", 109).
 yeccpars2_42_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   extract_token ( __1 )
-  end | __Stack].
-
--compile({inline,yeccpars2_43_/1}).
--file("src/graphql_parser.yrl", 120).
-yeccpars2_43_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    extract_keyword ( __1 )
   end | __Stack].
 
+-compile({inline,yeccpars2_43_/1}).
+-file("src/graphql_parser.yrl", 107).
+yeccpars2_43_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_token ( __1 )
+  end | __Stack].
+
 -compile({inline,yeccpars2_44_/1}).
--file("src/graphql_parser.yrl", 108).
+-file("src/graphql_parser.yrl", 119).
 yeccpars2_44_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2448,7 +2563,7 @@ yeccpars2_44_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_45_/1}).
--file("src/graphql_parser.yrl", 116).
+-file("src/graphql_parser.yrl", 122).
 yeccpars2_45_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2456,7 +2571,7 @@ yeccpars2_45_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_46_/1}).
--file("src/graphql_parser.yrl", 112).
+-file("src/graphql_parser.yrl", 108).
 yeccpars2_46_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -2471,709 +2586,725 @@ yeccpars2_47_(__Stack0) ->
    extract_keyword ( __1 )
   end | __Stack].
 
+-compile({inline,yeccpars2_48_/1}).
+-file("src/graphql_parser.yrl", 111).
+yeccpars2_48_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
 -compile({inline,yeccpars2_49_/1}).
--file("src/graphql_parser.yrl", 70).
+-file("src/graphql_parser.yrl", 114).
 yeccpars2_49_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   extract_keyword ( __1 )
+  end | __Stack].
+
+-compile({inline,yeccpars2_51_/1}).
+-file("src/graphql_parser.yrl", 70).
+yeccpars2_51_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentSpread' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_53_/1}).
+-compile({inline,yeccpars2_55_/1}).
 -file("src/graphql_parser.yrl", 56).
-yeccpars2_53_(__Stack0) ->
+yeccpars2_55_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'NamedType' , [ { name , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_54_/1}).
+-compile({inline,yeccpars2_56_/1}).
 -file("src/graphql_parser.yrl", 73).
-yeccpars2_54_(__Stack0) ->
+yeccpars2_56_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InlineFragment' , [ { typeCondition , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_56_/1}).
+-compile({inline,yeccpars2_58_/1}).
 -file("src/graphql_parser.yrl", 102).
-yeccpars2_56_(__Stack0) ->
+yeccpars2_58_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_58_/1}).
+-compile({inline,yeccpars2_60_/1}).
 -file("src/graphql_parser.yrl", 104).
-yeccpars2_58_(__Stack0) ->
+yeccpars2_60_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Directive' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_59_/1}).
+-compile({inline,yeccpars2_61_/1}).
 -file("src/graphql_parser.yrl", 105).
-yeccpars2_59_(__Stack0) ->
+yeccpars2_61_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Directive' , [ { name , __2 } , { arguments , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_63_/1}).
+-compile({inline,yeccpars2_65_/1}).
 -file("src/graphql_parser.yrl", 98).
-yeccpars2_63_(__Stack0) ->
+yeccpars2_65_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_64_/1}).
+-compile({inline,yeccpars2_66_/1}).
 -file("src/graphql_parser.yrl", 99).
-yeccpars2_64_(__Stack0) ->
+yeccpars2_66_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_65_/1}).
+-compile({inline,yeccpars2_67_/1}).
 -file("src/graphql_parser.yrl", 97).
-yeccpars2_65_(__Stack0) ->
+yeccpars2_67_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_68_/1}).
+-compile({inline,yeccpars2_70_/1}).
 -file("src/graphql_parser.yrl", 100).
-yeccpars2_68_(__Stack0) ->
+yeccpars2_70_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Argument' , [ { name , __1 } , { value , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_69_/1}).
--file("src/graphql_parser.yrl", 129).
-yeccpars2_69_(__Stack0) ->
+-compile({inline,yeccpars2_71_/1}).
+-file("src/graphql_parser.yrl", 131).
+yeccpars2_71_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectValue' , [ { fields , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_71_/1}).
--file("src/graphql_parser.yrl", 128).
-yeccpars2_71_(__Stack0) ->
+-compile({inline,yeccpars2_73_/1}).
+-file("src/graphql_parser.yrl", 130).
+yeccpars2_73_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ListValue' , [ { values , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_72_/1}).
--file("src/graphql_parser.yrl", 127).
-yeccpars2_72_(__Stack0) ->
+-compile({inline,yeccpars2_74_/1}).
+-file("src/graphql_parser.yrl", 129).
+yeccpars2_74_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'EnumValue' , [ { value , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_75_/1}).
--file("src/graphql_parser.yrl", 126).
-yeccpars2_75_(__Stack0) ->
+-compile({inline,yeccpars2_77_/1}).
+-file("src/graphql_parser.yrl", 128).
+yeccpars2_77_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'BooleanValue' , [ { value , extract_boolean ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_76_/1}).
--file("src/graphql_parser.yrl", 124).
-yeccpars2_76_(__Stack0) ->
+-compile({inline,yeccpars2_78_/1}).
+-file("src/graphql_parser.yrl", 126).
+yeccpars2_78_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FloatValue' , [ { value , extract_float ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_77_/1}).
--file("src/graphql_parser.yrl", 123).
-yeccpars2_77_(__Stack0) ->
+-compile({inline,yeccpars2_79_/1}).
+-file("src/graphql_parser.yrl", 125).
+yeccpars2_79_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'IntValue' , [ { value , extract_integer ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_78_/1}).
--file("src/graphql_parser.yrl", 125).
-yeccpars2_78_(__Stack0) ->
+-compile({inline,yeccpars2_80_/1}).
+-file("src/graphql_parser.yrl", 127).
+yeccpars2_80_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'StringValue' , [ { value , extract_token ( __1 ) } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_81_/1}).
--file("src/graphql_parser.yrl", 140).
-yeccpars2_81_(__Stack0) ->
+-compile({inline,yeccpars2_83_/1}).
+-file("src/graphql_parser.yrl", 142).
+yeccpars2_83_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_83_/1}).
--file("src/graphql_parser.yrl", 138).
-yeccpars2_83_(__Stack0) ->
+-compile({inline,yeccpars2_85_/1}).
+-file("src/graphql_parser.yrl", 140).
+yeccpars2_85_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ ]
   end | __Stack].
 
--compile({inline,yeccpars2_85_/1}).
--file("src/graphql_parser.yrl", 142).
-yeccpars2_85_(__Stack0) ->
+-compile({inline,yeccpars2_87_/1}).
+-file("src/graphql_parser.yrl", 144).
+yeccpars2_87_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectField' , [ { name , __1 } , { value , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_86_/1}).
--file("src/graphql_parser.yrl", 141).
-yeccpars2_86_(__Stack0) ->
+-compile({inline,yeccpars2_88_/1}).
+-file("src/graphql_parser.yrl", 143).
+yeccpars2_88_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_87_/1}).
--file("src/graphql_parser.yrl", 139).
-yeccpars2_87_(__Stack0) ->
+-compile({inline,yeccpars2_89_/1}).
+-file("src/graphql_parser.yrl", 141).
+yeccpars2_89_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_89_/1}).
--file("src/graphql_parser.yrl", 135).
-yeccpars2_89_(__Stack0) ->
+-compile({inline,yeccpars2_91_/1}).
+-file("src/graphql_parser.yrl", 137).
+yeccpars2_91_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_90_/1}).
--file("src/graphql_parser.yrl", 133).
-yeccpars2_90_(__Stack0) ->
+-compile({inline,yeccpars2_92_/1}).
+-file("src/graphql_parser.yrl", 135).
+yeccpars2_92_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ ]
   end | __Stack].
 
--compile({inline,yeccpars2_91_/1}).
--file("src/graphql_parser.yrl", 136).
-yeccpars2_91_(__Stack0) ->
+-compile({inline,yeccpars2_93_/1}).
+-file("src/graphql_parser.yrl", 138).
+yeccpars2_93_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_92_/1}).
--file("src/graphql_parser.yrl", 134).
-yeccpars2_92_(__Stack0) ->
+-compile({inline,yeccpars2_94_/1}).
+-file("src/graphql_parser.yrl", 136).
+yeccpars2_94_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_93_/1}).
+-compile({inline,yeccpars2_95_/1}).
 -file("src/graphql_parser.yrl", 49).
-yeccpars2_93_(__Stack0) ->
+yeccpars2_95_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Variable' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_94_/1}).
+-compile({inline,yeccpars2_96_/1}).
 -file("src/graphql_parser.yrl", 103).
-yeccpars2_94_(__Stack0) ->
+yeccpars2_96_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_95_/1}).
+-compile({inline,yeccpars2_97_/1}).
 -file("src/graphql_parser.yrl", 74).
-yeccpars2_95_(__Stack0) ->
+yeccpars2_97_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InlineFragment' , [ { typeCondition , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_96_/1}).
+-compile({inline,yeccpars2_98_/1}).
 -file("src/graphql_parser.yrl", 71).
-yeccpars2_96_(__Stack0) ->
+yeccpars2_98_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentSpread' , [ { name , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_97_/1}).
+-compile({inline,yeccpars2_99_/1}).
 -file("src/graphql_parser.yrl", 86).
-yeccpars2_97_(__Stack0) ->
+yeccpars2_99_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_98_/1}).
+-compile({inline,yeccpars2_100_/1}).
 -file("src/graphql_parser.yrl", 88).
-yeccpars2_98_(__Stack0) ->
+yeccpars2_100_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_99_/1}).
+-compile({inline,yeccpars2_101_/1}).
 -file("src/graphql_parser.yrl", 90).
-yeccpars2_99_(__Stack0) ->
+yeccpars2_101_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_100_/1}).
+-compile({inline,yeccpars2_102_/1}).
 -file("src/graphql_parser.yrl", 87).
-yeccpars2_100_(__Stack0) ->
+yeccpars2_102_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_101_/1}).
+-compile({inline,yeccpars2_103_/1}).
 -file("src/graphql_parser.yrl", 89).
-yeccpars2_101_(__Stack0) ->
+yeccpars2_103_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_102_/1}).
+-compile({inline,yeccpars2_104_/1}).
 -file("src/graphql_parser.yrl", 91).
-yeccpars2_102_(__Stack0) ->
+yeccpars2_104_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { directives , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_103_/1}).
+-compile({inline,yeccpars2_105_/1}).
 -file("src/graphql_parser.yrl", 93).
-yeccpars2_103_(__Stack0) ->
+yeccpars2_105_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { arguments , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_104_/1}).
+-compile({inline,yeccpars2_106_/1}).
 -file("src/graphql_parser.yrl", 92).
-yeccpars2_104_(__Stack0) ->
+yeccpars2_106_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { alias , __1 } , { name , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_105_/1}).
+-compile({inline,yeccpars2_107_/1}).
 -file("src/graphql_parser.yrl", 81).
-yeccpars2_105_(__Stack0) ->
+yeccpars2_107_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { selectionSet , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_106_/1}).
+-compile({inline,yeccpars2_108_/1}).
 -file("src/graphql_parser.yrl", 80).
-yeccpars2_106_(__Stack0) ->
+yeccpars2_108_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { directives , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_107_/1}).
+-compile({inline,yeccpars2_109_/1}).
 -file("src/graphql_parser.yrl", 79).
-yeccpars2_107_(__Stack0) ->
+yeccpars2_109_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_108_/1}).
+-compile({inline,yeccpars2_110_/1}).
 -file("src/graphql_parser.yrl", 95).
-yeccpars2_108_(__Stack0) ->
+yeccpars2_110_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    __1
   end | __Stack].
 
--compile({inline,yeccpars2_109_/1}).
+-compile({inline,yeccpars2_111_/1}).
 -file("src/graphql_parser.yrl", 83).
-yeccpars2_109_(__Stack0) ->
+yeccpars2_111_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_110_/1}).
+-compile({inline,yeccpars2_112_/1}).
 -file("src/graphql_parser.yrl", 84).
-yeccpars2_110_(__Stack0) ->
+yeccpars2_112_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { directives , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_111_/1}).
+-compile({inline,yeccpars2_113_/1}).
 -file("src/graphql_parser.yrl", 85).
-yeccpars2_111_(__Stack0) ->
+yeccpars2_113_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { arguments , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_112_/1}).
+-compile({inline,yeccpars2_114_/1}).
 -file("src/graphql_parser.yrl", 82).
-yeccpars2_112_(__Stack0) ->
+yeccpars2_114_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'Field' , [ { name , __1 } , { directives , __2 } , { selectionSet , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_113_/1}).
+-compile({inline,yeccpars2_115_/1}).
 -file("src/graphql_parser.yrl", 64).
-yeccpars2_113_(__Stack0) ->
+yeccpars2_115_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_114_/1}).
+-compile({inline,yeccpars2_116_/1}).
 -file("src/graphql_parser.yrl", 61).
-yeccpars2_114_(__Stack0) ->
+yeccpars2_116_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'SelectionSet' , { selections , __2 } )
   end | __Stack].
 
--compile({inline,yeccpars2_117_/1}).
--file("src/graphql_parser.yrl", 179).
-yeccpars2_117_(__Stack0) ->
+-compile({inline,yeccpars2_119_/1}).
+-file("src/graphql_parser.yrl", 181).
+yeccpars2_119_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'UnionTypeDefinition' , [ { name , __2 } , { types , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_118_/1}).
--file("src/graphql_parser.yrl", 181).
-yeccpars2_118_(__Stack0) ->
+-compile({inline,yeccpars2_120_/1}).
+-file("src/graphql_parser.yrl", 183).
+yeccpars2_120_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_120_/1}).
--file("src/graphql_parser.yrl", 182).
-yeccpars2_120_(__Stack0) ->
+-compile({inline,yeccpars2_122_/1}).
+-file("src/graphql_parser.yrl", 184).
+yeccpars2_122_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __3 ]
   end | __Stack].
 
--compile({inline,yeccpars2_127_/1}).
--file("src/graphql_parser.yrl", 162).
-yeccpars2_127_(__Stack0) ->
+-compile({inline,yeccpars2_129_/1}).
+-file("src/graphql_parser.yrl", 164).
+yeccpars2_129_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_128_/1}).
--file("src/graphql_parser.yrl", 163).
-yeccpars2_128_(__Stack0) ->
+-compile({inline,yeccpars2_130_/1}).
+-file("src/graphql_parser.yrl", 165).
+yeccpars2_130_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_129_/1}).
--file("src/graphql_parser.yrl", 153).
-yeccpars2_129_(__Stack0) ->
+-compile({inline,yeccpars2_131_/1}).
+-file("src/graphql_parser.yrl", 155).
+yeccpars2_131_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_133_/1}).
--file("src/graphql_parser.yrl", 164).
-yeccpars2_133_(__Stack0) ->
+-compile({inline,yeccpars2_135_/1}).
+-file("src/graphql_parser.yrl", 166).
+yeccpars2_135_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { type , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_139_/1}).
+-compile({inline,yeccpars2_141_/1}).
 -file("src/graphql_parser.yrl", 57).
-yeccpars2_139_(__Stack0) ->
+yeccpars2_141_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ListType' , [ { type , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_140_/1}).
+-compile({inline,yeccpars2_142_/1}).
 -file("src/graphql_parser.yrl", 59).
-yeccpars2_140_(__Stack0) ->
+yeccpars2_142_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_141_/1}).
+-compile({inline,yeccpars2_143_/1}).
 -file("src/graphql_parser.yrl", 58).
-yeccpars2_141_(__Stack0) ->
+yeccpars2_143_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'NonNullType' , [ { type , __1 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_144_/1}).
--file("src/graphql_parser.yrl", 169).
-yeccpars2_144_(__Stack0) ->
+-compile({inline,yeccpars2_146_/1}).
+-file("src/graphql_parser.yrl", 171).
+yeccpars2_146_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_145_/1}).
--file("src/graphql_parser.yrl", 170).
-yeccpars2_145_(__Stack0) ->
+-compile({inline,yeccpars2_147_/1}).
+-file("src/graphql_parser.yrl", 172).
+yeccpars2_147_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_146_/1}).
--file("src/graphql_parser.yrl", 167).
-yeccpars2_146_(__Stack0) ->
+-compile({inline,yeccpars2_148_/1}).
+-file("src/graphql_parser.yrl", 169).
+yeccpars2_148_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_148_/1}).
--file("src/graphql_parser.yrl", 172).
-yeccpars2_148_(__Stack0) ->
+-compile({inline,yeccpars2_150_/1}).
+-file("src/graphql_parser.yrl", 174).
+yeccpars2_150_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_149_/1}).
--file("src/graphql_parser.yrl", 173).
-yeccpars2_149_(__Stack0) ->
+-compile({inline,yeccpars2_151_/1}).
+-file("src/graphql_parser.yrl", 175).
+yeccpars2_151_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InputValueDefinition' , [ { name , __1 } , { type , __3 } , { defaultValue , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_151_/1}).
--file("src/graphql_parser.yrl", 51).
-yeccpars2_151_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   __2
-  end | __Stack].
-
 -compile({inline,yeccpars2_153_/1}).
--file("src/graphql_parser.yrl", 165).
+-file("src/graphql_parser.yrl", 51).
 yeccpars2_153_(__Stack0) ->
- [__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { arguments , __2 } , { type , __4 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_154_/1}).
--file("src/graphql_parser.yrl", 157).
-yeccpars2_154_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
 -compile({inline,yeccpars2_155_/1}).
--file("src/graphql_parser.yrl", 159).
+-file("src/graphql_parser.yrl", 167).
 yeccpars2_155_(__Stack0) ->
+ [__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'FieldDefinition' , [ { name , __1 } , { arguments , __2 } , { type , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_156_/1}).
+-file("src/graphql_parser.yrl", 159).
+yeccpars2_156_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   __2
+  end | __Stack].
+
+-compile({inline,yeccpars2_157_/1}).
+-file("src/graphql_parser.yrl", 161).
+yeccpars2_157_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_156_/1}).
--file("src/graphql_parser.yrl", 160).
-yeccpars2_156_(__Stack0) ->
+-compile({inline,yeccpars2_158_/1}).
+-file("src/graphql_parser.yrl", 162).
+yeccpars2_158_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_159_/1}).
--file("src/graphql_parser.yrl", 155).
-yeccpars2_159_(__Stack0) ->
+-compile({inline,yeccpars2_161_/1}).
+-file("src/graphql_parser.yrl", 157).
+yeccpars2_161_(__Stack0) ->
  [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ObjectTypeDefinition' , [ { name , __2 } , { interfaces , __3 } , { fields , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_160_/1}).
--file("src/graphql_parser.yrl", 184).
-yeccpars2_160_(__Stack0) ->
+-compile({inline,yeccpars2_162_/1}).
+-file("src/graphql_parser.yrl", 186).
+yeccpars2_162_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'ScalarTypeDefinition' , [ { name , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_164_/1}).
--file("src/graphql_parser.yrl", 176).
-yeccpars2_164_(__Stack0) ->
+-compile({inline,yeccpars2_166_/1}).
+-file("src/graphql_parser.yrl", 178).
+yeccpars2_166_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InterfaceTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_168_/1}).
--file("src/graphql_parser.yrl", 195).
-yeccpars2_168_(__Stack0) ->
+-compile({inline,yeccpars2_170_/1}).
+-file("src/graphql_parser.yrl", 197).
+yeccpars2_170_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'InputObjectTypeDefinition' , [ { name , __2 } , { fields , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_172_/1}).
+-compile({inline,yeccpars2_174_/1}).
 -file("src/graphql_parser.yrl", 39).
-yeccpars2_172_(__Stack0) ->
+yeccpars2_174_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_174_/1}).
+-compile({inline,yeccpars2_176_/1}).
 -file("src/graphql_parser.yrl", 40).
-yeccpars2_174_(__Stack0) ->
+yeccpars2_176_(__Stack0) ->
  [__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'FragmentDefinition' , [ { name , __2 } , { typeCondition , __4 } , { directives , __5 } , { selectionSet , __6 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_175_/1}).
--file("src/graphql_parser.yrl", 198).
-yeccpars2_175_(__Stack0) ->
+-compile({inline,yeccpars2_177_/1}).
+-file("src/graphql_parser.yrl", 200).
+yeccpars2_177_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'TypeExtensionDefinition' , [ { definition , __2 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_179_/1}).
--file("src/graphql_parser.yrl", 189).
-yeccpars2_179_(__Stack0) ->
+-compile({inline,yeccpars2_181_/1}).
+-file("src/graphql_parser.yrl", 191).
+yeccpars2_181_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ __1 ]
   end | __Stack].
 
--compile({inline,yeccpars2_181_/1}).
--file("src/graphql_parser.yrl", 190).
-yeccpars2_181_(__Stack0) ->
- [__2,__1 | __Stack] = __Stack0,
- [begin
-   [ __1 | __2 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_182_/1}).
--file("src/graphql_parser.yrl", 187).
-yeccpars2_182_(__Stack0) ->
- [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'EnumTypeDefinition' , [ { name , __2 } , { values , __4 } ] )
-  end | __Stack].
-
 -compile({inline,yeccpars2_183_/1}).
--file("src/graphql_parser.yrl", 24).
+-file("src/graphql_parser.yrl", 192).
 yeccpars2_183_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_186_/1}).
--file("src/graphql_parser.yrl", 34).
-yeccpars2_186_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
+-compile({inline,yeccpars2_184_/1}).
+-file("src/graphql_parser.yrl", 189).
+yeccpars2_184_(__Stack0) ->
+ [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { selectionSet , __3 } ] )
+   build_ast_node ( 'EnumTypeDefinition' , [ { name , __2 } , { values , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_190_/1}).
--file("src/graphql_parser.yrl", 45).
-yeccpars2_190_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
- [begin
-   [ __1 ]
-  end | __Stack].
-
--compile({inline,yeccpars2_193_/1}).
--file("src/graphql_parser.yrl", 47).
-yeccpars2_193_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_194_/1}).
--file("src/graphql_parser.yrl", 48).
-yeccpars2_194_(__Stack0) ->
- [__4,__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } , { defaultValue , __4 } ] )
-  end | __Stack].
-
--compile({inline,yeccpars2_195_/1}).
--file("src/graphql_parser.yrl", 46).
-yeccpars2_195_(__Stack0) ->
+-compile({inline,yeccpars2_185_/1}).
+-file("src/graphql_parser.yrl", 24).
+yeccpars2_185_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
+-compile({inline,yeccpars2_188_/1}).
+-file("src/graphql_parser.yrl", 34).
+yeccpars2_188_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { selectionSet , __3 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_192_/1}).
+-file("src/graphql_parser.yrl", 45).
+yeccpars2_192_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_195_/1}).
+-file("src/graphql_parser.yrl", 47).
+yeccpars2_195_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } ] )
+  end | __Stack].
+
 -compile({inline,yeccpars2_196_/1}).
--file("src/graphql_parser.yrl", 44).
+-file("src/graphql_parser.yrl", 48).
 yeccpars2_196_(__Stack0) ->
+ [__4,__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   build_ast_node ( 'VariableDefinition' , [ { variable , __1 } , { type , __3 } , { defaultValue , __4 } ] )
+  end | __Stack].
+
+-compile({inline,yeccpars2_197_/1}).
+-file("src/graphql_parser.yrl", 46).
+yeccpars2_197_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 | __2 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_198_/1}).
+-file("src/graphql_parser.yrl", 44).
+yeccpars2_198_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    __2
   end | __Stack].
 
--compile({inline,yeccpars2_197_/1}).
+-compile({inline,yeccpars2_199_/1}).
 -file("src/graphql_parser.yrl", 36).
-yeccpars2_197_(__Stack0) ->
+yeccpars2_199_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { directives , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_198_/1}).
+-compile({inline,yeccpars2_200_/1}).
 -file("src/graphql_parser.yrl", 35).
-yeccpars2_198_(__Stack0) ->
+yeccpars2_200_(__Stack0) ->
  [__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { variableDefinitions , __3 } , { selectionSet , __4 } ] )
   end | __Stack].
 
--compile({inline,yeccpars2_200_/1}).
+-compile({inline,yeccpars2_202_/1}).
 -file("src/graphql_parser.yrl", 37).
-yeccpars2_200_(__Stack0) ->
+yeccpars2_202_(__Stack0) ->
  [__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    build_ast_node ( 'OperationDefinition' , [ { operation , __1 } , { name , __2 } , { variableDefinitions , __3 } , { directives , __4 } , { selectionSet , __5 } ] )
   end | __Stack].
 
 
--file("src/graphql_parser.yrl", 220).
+-file("src/graphql_parser.yrl", 222).

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -7,7 +7,7 @@ Nonterminals
   InputValueDefinitionList InputValueDefinition UnionMembers
   EnumValueDefinitionList EnumValueDefinition
   SelectionSet Selections Selection
-  OperationType Name VariableDefinitions VariableDefinition Directives Directive
+  OperationType Name NameWithoutOn VariableDefinitions VariableDefinition Directives Directive
   Field Alias Arguments ArgumentList Argument
   FragmentSpread FragmentName InlineFragment
   VariableDefinitionList Variable DefaultValue
@@ -77,7 +77,7 @@ FragmentSpread -> '...' FragmentName Directives : build_ast_node('FragmentSpread
 InlineFragment -> '...' 'on' TypeCondition SelectionSet : build_ast_node('InlineFragment', [{'typeCondition', '$3'}, {'selectionSet', '$4'}]).
 InlineFragment -> '...' 'on' TypeCondition Directives SelectionSet : build_ast_node('InlineFragment', [{'typeCondition', '$3'}, {'directives', '$4'}, {'selectionSet', '$5'}]).
 
-FragmentName -> Name : '$1'.
+FragmentName -> NameWithoutOn : '$1'.
 
 Field -> Name : build_ast_node('Field', {'name', '$1'}).
 Field -> Name Arguments : build_ast_node('Field', [{'name', '$1'}, {'arguments', '$2'}]).
@@ -108,20 +108,22 @@ Directives -> Directive Directives : ['$1'|'$2'].
 Directive -> '@' Name : build_ast_node('Directive', [{name, '$2'}]).
 Directive -> '@' Name Arguments : build_ast_node('Directive', [{name, '$2'}, {'arguments', '$3'}]).
 
-Name -> name : extract_token('$1').
-Name -> 'query' : extract_keyword('$1').
-Name -> 'mutation' : extract_keyword('$1').
-Name -> 'fragment' : extract_keyword('$1').
-% Name -> 'on' : extract_keyword('$1').
-Name -> 'type' : extract_keyword('$1').
-Name -> 'implements' : extract_keyword('$1').
-Name -> 'interface' : extract_keyword('$1').
-Name -> 'union' : extract_keyword('$1').
-Name -> 'scalar' : extract_keyword('$1').
-Name -> 'enum' : extract_keyword('$1').
-Name -> 'input' : extract_keyword('$1').
-Name -> 'extend' : extract_keyword('$1').
-Name -> 'null' : extract_keyword('$1').
+NameWithoutOn -> name : extract_token('$1').
+NameWithoutOn -> 'query' : extract_keyword('$1').
+NameWithoutOn -> 'mutation' : extract_keyword('$1').
+NameWithoutOn -> 'fragment' : extract_keyword('$1').
+NameWithoutOn -> 'type' : extract_keyword('$1').
+NameWithoutOn -> 'implements' : extract_keyword('$1').
+NameWithoutOn -> 'interface' : extract_keyword('$1').
+NameWithoutOn -> 'union' : extract_keyword('$1').
+NameWithoutOn -> 'scalar' : extract_keyword('$1').
+NameWithoutOn -> 'enum' : extract_keyword('$1').
+NameWithoutOn -> 'input' : extract_keyword('$1').
+NameWithoutOn -> 'extend' : extract_keyword('$1').
+NameWithoutOn -> 'null' : extract_keyword('$1').
+
+Name -> NameWithoutOn : '$1'.
+Name -> 'on' : extract_keyword('$1').
 
 Value -> Variable : '$1'.
 Value -> int_value : build_ast_node('IntValue', [{'value', extract_integer('$1')}]).

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -16,7 +16,7 @@ Nonterminals
 
 Terminals
   '{' '}' '(' ')' '[' ']' '!' ':' '@' '$' '=' '|' '...'
-  'query' 'mutation' 'fragment' 'on'
+  'query' 'mutation' 'fragment' 'on' 'null'
   'type' 'implements' 'interface' 'union' 'scalar' 'enum' 'input' 'extend'
   name int_value float_value string_value boolean_value.
 
@@ -109,6 +109,19 @@ Directive -> '@' Name : build_ast_node('Directive', [{name, '$2'}]).
 Directive -> '@' Name Arguments : build_ast_node('Directive', [{name, '$2'}, {'arguments', '$3'}]).
 
 Name -> name : extract_token('$1').
+Name -> 'query' : extract_keyword('$1').
+Name -> 'mutation' : extract_keyword('$1').
+Name -> 'fragment' : extract_keyword('$1').
+Name -> 'on' : extract_keyword('$1').
+Name -> 'type' : extract_keyword('$1').
+Name -> 'implements' : extract_keyword('$1').
+Name -> 'interface' : extract_keyword('$1').
+Name -> 'union' : extract_keyword('$1').
+Name -> 'scalar' : extract_keyword('$1').
+Name -> 'enum' : extract_keyword('$1').
+Name -> 'input' : extract_keyword('$1').
+Name -> 'extend' : extract_keyword('$1').
+Name -> 'null' : extract_keyword('$1').
 
 Value -> Variable : '$1'.
 Value -> int_value : build_ast_node('IntValue', [{'value', extract_integer('$1')}]).
@@ -198,6 +211,7 @@ extract_float({_Token, _Line, Value}) ->
   {Float, []} = string:to_float(Value), Float.
 extract_boolean({_Token, _Line, "true"}) -> true;
 extract_boolean({_Token, _Line, "false"}) -> false.
+extract_keyword({Value, _Line}) -> atom_to_list(Value).
 
 build_ast_node(Type, Tuple) when is_list(Tuple) ->
   [{kind, Type}, {loc, [{start, 0}]}] ++ Tuple;

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -112,7 +112,7 @@ Name -> name : extract_token('$1').
 Name -> 'query' : extract_keyword('$1').
 Name -> 'mutation' : extract_keyword('$1').
 Name -> 'fragment' : extract_keyword('$1').
-Name -> 'on' : extract_keyword('$1').
+% Name -> 'on' : extract_keyword('$1').
 Name -> 'type' : extract_keyword('$1').
 Name -> 'implements' : extract_keyword('$1').
 Name -> 'interface' : extract_keyword('$1').

--- a/test/graphql_parser_introspection_test.exs
+++ b/test/graphql_parser_introspection_test.exs
@@ -39,7 +39,7 @@ defmodule GraphqlParserIntrospectionTest do
           args {
             ...InputValue
           }
-          _type {
+          type {
             ...TypeRef
           }
           isDeprecated
@@ -64,7 +64,7 @@ defmodule GraphqlParserIntrospectionTest do
       fragment InputValue on __InputValue {
         name
         description
-        _type { ...TypeRef }
+        type { ...TypeRef }
         defaultValue
       }
       fragment TypeRef on __Type {
@@ -83,6 +83,90 @@ defmodule GraphqlParserIntrospectionTest do
           }
         }
       }
-    """, []
+    """,
+    [kind: :Document, loc: [start: 0],
+            definitions: [[kind: :OperationDefinition, loc: [start: 0], operation: :query,
+              name: 'IntrospectionQuery',
+              selectionSet: [kind: :SelectionSet, loc: [start: 0],
+               selections: [[kind: :Field, loc: [start: 0], name: '__schema',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :Field, loc: [start: 0], name: 'queryType',
+                    selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                     selections: [[kind: :Field, loc: [start: 0], name: 'name']]]],
+                   [kind: :Field, loc: [start: 0], name: 'mutationType',
+                    selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                     selections: [[kind: :Field, loc: [start: 0], name: 'name']]]],
+                   [kind: :Field, loc: [start: 0], name: 'types',
+                    selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                     selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'FullType']]]],
+                   [kind: :Field, loc: [start: 0], name: 'directives',
+                    selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                     selections: [[kind: :Field, loc: [start: 0], name: 'name'],
+                      [kind: :Field, loc: [start: 0], name: 'description'],
+                      [kind: :Field, loc: [start: 0], name: 'args',
+                       selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                        selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'InputValue']]]],
+                      [kind: :Field, loc: [start: 0], name: 'onOperation'],
+                      [kind: :Field, loc: [start: 0], name: 'onFragment'],
+                      [kind: :Field, loc: [start: 0], name: 'onField']]]]]]]]]],
+             [kind: :FragmentDefinition, loc: [start: 0], name: 'FullType',
+              typeCondition: [kind: :NamedType, loc: [start: 0], name: '__Type'],
+              selectionSet: [kind: :SelectionSet, loc: [start: 0],
+               selections: [[kind: :Field, loc: [start: 0], name: 'kind'],
+                [kind: :Field, loc: [start: 0], name: 'name'],
+                [kind: :Field, loc: [start: 0], name: 'description'],
+                [kind: :Field, loc: [start: 0], name: 'fields',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :Field, loc: [start: 0], name: 'name'],
+                   [kind: :Field, loc: [start: 0], name: 'description'],
+                   [kind: :Field, loc: [start: 0], name: 'args',
+                    selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                     selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'InputValue']]]],
+                   [kind: :Field, loc: [start: 0], name: 'type',
+                    selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                     selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'TypeRef']]]],
+                   [kind: :Field, loc: [start: 0], name: 'isDeprecated'],
+                   [kind: :Field, loc: [start: 0], name: 'deprecationReason']]]],
+                [kind: :Field, loc: [start: 0], name: 'inputFields',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'InputValue']]]],
+                [kind: :Field, loc: [start: 0], name: 'interfaces',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'TypeRef']]]],
+                [kind: :Field, loc: [start: 0], name: 'enumValues',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :Field, loc: [start: 0], name: 'name'],
+                   [kind: :Field, loc: [start: 0], name: 'description'],
+                   [kind: :Field, loc: [start: 0], name: 'isDeprecated'],
+                   [kind: :Field, loc: [start: 0], name: 'deprecationReason']]]],
+                [kind: :Field, loc: [start: 0], name: 'possibleTypes',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'TypeRef']]]]]]],
+             [kind: :FragmentDefinition, loc: [start: 0], name: 'InputValue',
+              typeCondition: [kind: :NamedType, loc: [start: 0], name: '__InputValue'],
+              selectionSet: [kind: :SelectionSet, loc: [start: 0],
+               selections: [[kind: :Field, loc: [start: 0], name: 'name'],
+                [kind: :Field, loc: [start: 0], name: 'description'],
+                [kind: :Field, loc: [start: 0], name: 'type',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :FragmentSpread, loc: [start: 0], name: 'TypeRef']]]],
+                [kind: :Field, loc: [start: 0], name: 'defaultValue']]]],
+             [kind: :FragmentDefinition, loc: [start: 0], name: 'TypeRef',
+              typeCondition: [kind: :NamedType, loc: [start: 0], name: '__Type'],
+              selectionSet: [kind: :SelectionSet, loc: [start: 0],
+               selections: [[kind: :Field, loc: [start: 0], name: 'kind'],
+                [kind: :Field, loc: [start: 0], name: 'name'],
+                [kind: :Field, loc: [start: 0], name: 'ofType',
+                 selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                  selections: [[kind: :Field, loc: [start: 0], name: 'kind'],
+                   [kind: :Field, loc: [start: 0], name: 'name'],
+                   [kind: :Field, loc: [start: 0], name: 'ofType',
+                    selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                     selections: [[kind: :Field, loc: [start: 0], name: 'kind'],
+                      [kind: :Field, loc: [start: 0], name: 'name'],
+                      [kind: :Field, loc: [start: 0], name: 'ofType',
+                       selectionSet: [kind: :SelectionSet, loc: [start: 0],
+                        selections: [[kind: :Field, loc: [start: 0], name: 'kind'],
+                         [kind: :Field, loc: [start: 0], name: 'name']]]]]]]]]]]]]]]
   end
 end

--- a/test/graphql_parser_introspection_test.exs
+++ b/test/graphql_parser_introspection_test.exs
@@ -1,0 +1,88 @@
+defmodule GraphqlParserIntrospectionTest do
+  use ExUnit.Case, async: true
+
+  def assert_parse(input_string, expected_output) do
+    assert GraphQL.parse(input_string) == expected_output
+  end
+
+  test "Introspection Query" do
+    assert_parse """
+      # The introspection query to end all introspection queries, copied from
+      # https://github.com/graphql/graphql-js/blob/master/src/utilities/introspectionQuery.js
+
+      query IntrospectionQuery {
+        __schema {
+          queryType { name }
+          mutationType { name }
+          types {
+            ...FullType
+          }
+          directives {
+            name
+            description
+            args {
+              ...InputValue
+            }
+            onOperation
+            onFragment
+            onField
+          }
+        }
+      }
+      fragment FullType on __Type {
+        kind
+        name
+        description
+        fields {
+          name
+          description
+          args {
+            ...InputValue
+          }
+          type {
+            ...TypeRef
+          }
+          isDeprecated
+          deprecationReason
+        }
+        inputFields {
+          ...InputValue
+        }
+        interfaces {
+          ...TypeRef
+        }
+        enumValues {
+          name
+          description
+          isDeprecated
+          deprecationReason
+        }
+        possibleTypes {
+          ...TypeRef
+        }
+      }
+      fragment InputValue on __InputValue {
+        name
+        description
+        type { ...TypeRef }
+        defaultValue
+      }
+      fragment TypeRef on __Type {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    """, []
+  end
+end

--- a/test/graphql_parser_introspection_test.exs
+++ b/test/graphql_parser_introspection_test.exs
@@ -39,7 +39,7 @@ defmodule GraphqlParserIntrospectionTest do
           args {
             ...InputValue
           }
-          type {
+          _type {
             ...TypeRef
           }
           isDeprecated
@@ -64,7 +64,7 @@ defmodule GraphqlParserIntrospectionTest do
       fragment InputValue on __InputValue {
         name
         description
-        type { ...TypeRef }
+        _type { ...TypeRef }
         defaultValue
       }
       fragment TypeRef on __Type {

--- a/test/graphql_parser_kitchen_sink_test.exs
+++ b/test/graphql_parser_kitchen_sink_test.exs
@@ -104,6 +104,6 @@ defmodule GraphqlParserKitchenSinkTest do
                value: [kind: :BooleanValue, loc: [start: 0], value: true]],
               [kind: :Argument, loc: [start: 0], name: 'falsey',
                value: [kind: :BooleanValue, loc: [start: 0], value: false]]]],
-            [kind: :Field, loc: [start: 0], name: 'qry']]]]]]
+            [kind: :Field, loc: [start: 0], name: 'query']]]]]]
   end
 end

--- a/test/graphql_parser_kitchen_sink_test.exs
+++ b/test/graphql_parser_kitchen_sink_test.exs
@@ -36,7 +36,7 @@ defmodule GraphqlParserKitchenSinkTest do
 
       {
         unnamed(truthy: true, falsey: false),
-        qry
+        query
       }
     """,
       [kind: :Document, loc: [start: 0],

--- a/test/graphql_parser_test.exs
+++ b/test/graphql_parser_test.exs
@@ -423,7 +423,7 @@ defmodule GraphqlParserTest do
   end
 
   test "Use reserved words as fields" do
-    assert_parse "{ query mutation fragment on type implements interface union scalar enum input extend null }",
+    assert_parse "{ query mutation fragment type implements interface union scalar enum input extend null }",
       [kind: :Document, loc: [start: 0],
         definitions: [[kind: :OperationDefinition, loc: [start: 0],
           operation: :query,
@@ -432,7 +432,6 @@ defmodule GraphqlParserTest do
               [kind: :Field, loc: [start: 0], name: 'query'],
               [kind: :Field, loc: [start: 0], name: 'mutation'],
               [kind: :Field, loc: [start: 0], name: 'fragment'],
-              [kind: :Field, loc: [start: 0], name: 'on'],
               [kind: :Field, loc: [start: 0], name: 'type'],
               [kind: :Field, loc: [start: 0], name: 'implements'],
               [kind: :Field, loc: [start: 0], name: 'interface'],

--- a/test/graphql_parser_test.exs
+++ b/test/graphql_parser_test.exs
@@ -422,16 +422,26 @@ defmodule GraphqlParserTest do
                   type: [kind: :NamedType, loc: [start: 0], name: 'Boolean']]]]]]]
   end
 
-  # test "Use reserved words as fields" do
-  #   assert_parse "{ query fragment on }",
-  #     [kind: :Document, loc: [start: 0],
-  #       definitions: [[kind: :OperationDefinition, loc: [start: 0],
-  #         operation: :query,
-  #         selectionSet: [kind: :SelectionSet, loc: [start: 0],
-  #           selections: [
-  #             [kind: :Field, loc: [start: 0], name: 'query'],
-  #             [kind: :Field, loc: [start: 0], name: 'fragment'],
-  #             [kind: :Field, loc: [start: 0], name: 'on']]]]]]
-  #
-  # end
+  test "Use reserved words as fields" do
+    assert_parse "{ query mutation fragment on type implements interface union scalar enum input extend null }",
+      [kind: :Document, loc: [start: 0],
+        definitions: [[kind: :OperationDefinition, loc: [start: 0],
+          operation: :query,
+          selectionSet: [kind: :SelectionSet, loc: [start: 0],
+            selections: [
+              [kind: :Field, loc: [start: 0], name: 'query'],
+              [kind: :Field, loc: [start: 0], name: 'mutation'],
+              [kind: :Field, loc: [start: 0], name: 'fragment'],
+              [kind: :Field, loc: [start: 0], name: 'on'],
+              [kind: :Field, loc: [start: 0], name: 'type'],
+              [kind: :Field, loc: [start: 0], name: 'implements'],
+              [kind: :Field, loc: [start: 0], name: 'interface'],
+              [kind: :Field, loc: [start: 0], name: 'union'],
+              [kind: :Field, loc: [start: 0], name: 'scalar'],
+              [kind: :Field, loc: [start: 0], name: 'enum'],
+              [kind: :Field, loc: [start: 0], name: 'input'],
+              [kind: :Field, loc: [start: 0], name: 'extend'],
+              [kind: :Field, loc: [start: 0], name: 'null']]]]]]
+
+  end
 end

--- a/test/graphql_parser_test.exs
+++ b/test/graphql_parser_test.exs
@@ -423,7 +423,7 @@ defmodule GraphqlParserTest do
   end
 
   test "Use reserved words as fields" do
-    assert_parse "{ query mutation fragment type implements interface union scalar enum input extend null }",
+    assert_parse "{ query mutation fragment on type implements interface union scalar enum input extend null }",
       [kind: :Document, loc: [start: 0],
         definitions: [[kind: :OperationDefinition, loc: [start: 0],
           operation: :query,
@@ -432,6 +432,7 @@ defmodule GraphqlParserTest do
               [kind: :Field, loc: [start: 0], name: 'query'],
               [kind: :Field, loc: [start: 0], name: 'mutation'],
               [kind: :Field, loc: [start: 0], name: 'fragment'],
+              [kind: :Field, loc: [start: 0], name: 'on'],
               [kind: :Field, loc: [start: 0], name: 'type'],
               [kind: :Field, loc: [start: 0], name: 'implements'],
               [kind: :Field, loc: [start: 0], name: 'interface'],


### PR DESCRIPTION
`query`, `mutation`, etc are all now allowed as field names etc

Paired with @freshtonic 
