### PR TITLE
Added support for object fields

### DIFF
--- a/lib/graphql/exceptions.ex
+++ b/lib/graphql/exceptions.ex
@@ -8,3 +8,15 @@ defmodule GraphQL.SyntaxError do
     "#{exception.errors} on line #{exception.line}"
   end
 end
+
+defmodule GraphQL.QueryError do 
+  @moduledoc """
+  An error raised when a field is queried that does not exist
+  """
+
+  defexception line: nil, errors: "Query error", param: nil
+  def message(exception) do
+    ""
+  end
+end
+

--- a/lib/graphql/exceptions.ex
+++ b/lib/graphql/exceptions.ex
@@ -9,14 +9,3 @@ defmodule GraphQL.SyntaxError do
   end
 end
 
-defmodule GraphQL.QueryError do 
-  @moduledoc """
-  An error raised when a field is queried that does not exist
-  """
-
-  defexception line: nil, errors: "Query error", param: nil
-  def message(exception) do
-    ""
-  end
-end
-

--- a/test/graphql_executor_test.exs
+++ b/test/graphql_executor_test.exs
@@ -16,6 +16,16 @@ defmodule GraphqlExecutorTest do
               name: "greeting",
               type: "String",
               resolve: &greeting/1,
+            },
+            %GraphQL.ObjectType{
+              name: "person",
+              fields: [
+                %GraphQL.FieldDefinition{
+                  name: "name",
+                  type: "String",
+                  resolve: &person_name/1
+                }
+              ]
             }
           ]
         }
@@ -24,6 +34,8 @@ defmodule GraphqlExecutorTest do
 
     def greeting(name: name), do: "Hello, #{name}!"
     def greeting(_), do: greeting(name: "world")
+
+    def person_name(_), do: "Nick"
   end
 
   test "basic query execution" do
@@ -35,6 +47,22 @@ defmodule GraphqlExecutorTest do
     query = "{ greeting(name: \"Elixir\") }"
     assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{greeting: "Hello, Elixir!"}}
   end
+
+  test "query object type fields" do
+    query = "{ greeting, person { name } }"
+    assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{greeting: "Hello, world!", person: %{name: "Nick"} }}
+  end
+
+  test "query undefined field" do
+    query = "{ undefined }"
+    assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{}}
+  end
+
+  test "query nested undefined field" do 
+    query = "{ greeting, person { title } }"
+    assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{greeting: "Hello, world!"}}
+  end
+
 
 
   # test "simple selection set" do


### PR DESCRIPTION
Allows queries to select for fields inside of
object type fields.

Example:

``` graphql
{
  greeting
  person {
    name
    title
  }
}
```

will yield:

``` json
{
  "greeting": "Hello world!",
  "person": {
      "name": "Nick Gartmann",
      "title": "Mr."
    }
}
```

Currently relying on placing an ObjectType in the fields list for the schema [(see here)](https://github.com/joshprice/graphql-elixir/compare/master...nickgartmann:object-fields?expand=1#diff-a4131996d0bf8e381229a5fed3048942R20). An argument could be made for having an ObjectType return from `FieldDefinition.resolve/1` and having that properly get handled, but the direct placement into the schema made the schema more readable so I went with this.
