### PR TITLE
Revert "Added support for object fields"

### DIFF
--- a/lib/graphql.ex
+++ b/lib/graphql.ex
@@ -30,6 +30,9 @@ defmodule GraphQL do
       # {:ok, %{hello: "world"}}
   """
 
+  alias GraphQL.Schema
+  alias GraphQL.SyntaxError
+
   defmodule ObjectType do
     defstruct name: "RootQueryType", description: "", fields: []
   end
@@ -93,47 +96,28 @@ defmodule GraphQL do
   """
   def execute(schema, query) do
     case parse(query) do
-      {:ok, document} -> execute_definition(hd(document[:definitions]), schema)
+      {:ok, document} ->
+        query_fields = hd(document[:definitions])[:selectionSet][:selections]
+
+        %Schema{
+          query: _query_root = %ObjectType{
+            name: "RootQueryType",
+            fields: fields
+          }
+        } = schema
+
+        result = for fd <- fields, qf <- query_fields, qf[:name] == fd.name do
+          arguments = Map.get(qf, :arguments, [])
+                      |> Enum.map(&parse_argument/1)
+
+          {String.to_atom(fd.name), fd.resolve.(arguments)}
+        end
+
+        {:ok, Enum.into(result, %{})}
       {:error, error} -> {:error, error}
     end
   end
 
-  defp execute_definition(%{operation: :query}=definition, schema) do
-    {:ok, Enum.map(definition[:selectionSet][:selections], fn(selection) -> execute_field(selection, schema.query) end)
-          |> Enum.filter(fn(item) -> item != nil end)
-          |> Enum.into(%{})}
-  end
-
-  defp execute_field(%{kind: :Field, selectionSet: selection_set}=field, schema) do
-    fields = Enum.map(selection_set[:selections], fn(selection) -> 
-        schema_fragment = Enum.find(schema.fields, fn(fd) -> fd.name == field[:name] end)
-        execute_field(selection, schema_fragment) 
-      end)
-
-    fields = Enum.filter(fields, fn(item) -> item != nil end)
-
-    if Enum.count(fields) > 0 do
-      {String.to_atom(field[:name]), Enum.into(fields, %{})}
-    else
-      nil
-    end
-
-  end
-
-  defp execute_field(%{kind: :Field}=field, schema) do
-    arguments = Map.get(field, :arguments, []) |> Enum.map(&parse_argument/1)
-    schema_fragment = Enum.find(schema.fields, fn(fd) -> fd.name == field[:name] end)
-    case resolve(schema_fragment, arguments) do
-      {:ok, value} -> {String.to_atom(field[:name]), value}
-      {:error, _} -> nil
-    end
-  end
-
-  defp resolve(nil, _), do: {:error, nil}
-  defp resolve(field, arguments) do
-    {:ok, field.resolve.(arguments)}
-  end
-  
   defp parse_argument(%{kind: :Argument, loc: _, name: name, value: %{kind: _, loc: _, value: value}}) do
     {String.to_atom(name), value}
   end

--- a/lib/graphql/exceptions.ex
+++ b/lib/graphql/exceptions.ex
@@ -8,4 +8,3 @@ defmodule GraphQL.SyntaxError do
     "#{exception.errors} on line #{exception.line}"
   end
 end
-

--- a/test/graphql_executor_test.exs
+++ b/test/graphql_executor_test.exs
@@ -16,16 +16,6 @@ defmodule GraphqlExecutorTest do
               name: "greeting",
               type: "String",
               resolve: &greeting/1,
-            },
-            %GraphQL.ObjectType{
-              name: "person",
-              fields: [
-                %GraphQL.FieldDefinition{
-                  name: "name",
-                  type: "String",
-                  resolve: &person_name/1
-                }
-              ]
             }
           ]
         }
@@ -34,8 +24,6 @@ defmodule GraphqlExecutorTest do
 
     def greeting(name: name), do: "Hello, #{name}!"
     def greeting(_), do: greeting(name: "world")
-
-    def person_name(_), do: "Nick"
   end
 
   test "basic query execution" do
@@ -47,22 +35,6 @@ defmodule GraphqlExecutorTest do
     query = "{ greeting(name: \"Elixir\") }"
     assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{greeting: "Hello, Elixir!"}}
   end
-
-  test "query object type fields" do
-    query = "{ greeting, person { name } }"
-    assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{greeting: "Hello, world!", person: %{name: "Nick"} }}
-  end
-
-  test "query undefined field" do
-    query = "{ undefined }"
-    assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{}}
-  end
-
-  test "query nested undefined field" do 
-    query = "{ greeting, person { title } }"
-    assert GraphQL.execute(TestSchema.schema, query) == {:ok, %{greeting: "Hello, world!"}}
-  end
-
 
 
   # test "simple selection set" do


### PR DESCRIPTION
Sorry to revert this, but merged this prematurely and ended up following the reference implementation pretty closely which made for a very tricky rebase.

Can we add back what is needed in a new PR as I think most of this is now covered in master?

Reverts joshprice/graphql-elixir#23
