### PR TITLE
Typeless inline fragments

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -67,7 +67,8 @@ defmodule GraphQL.Execution.Executor do
     Enum.reduce selection_set[:selections], field_fragment_map, fn(selection, field_fragment_map) ->
       case selection do
         %{kind: :Field} -> put_in(field_fragment_map.fields[field_entry_key(selection)], [selection])
-        %{kind: :InlineFragment} -> field_fragment_map
+        %{kind: :InlineFragment} ->
+          collect_fields(context, runtime_type, selection.selectionSet, field_fragment_map)
         %{kind: :FragmentSpread} ->
           fragment_name = selection.name.value
           if !field_fragment_map.fragments[fragment_name] do

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -74,6 +74,9 @@ Selection -> InlineFragment : '$1'.
 FragmentSpread -> '...' FragmentName : build_ast_node('FragmentSpread', #{'name' => extract_name('$2')}).
 FragmentSpread -> '...' FragmentName Directives : build_ast_node('FragmentSpread', #{'name' => extract_name('$2'), 'directives' => '$3'}).
 
+InlineFragment -> '...' SelectionSet : build_ast_node('InlineFragment', #{'selectionSet' => '$2'}).
+InlineFragment -> '...' Directives SelectionSet : build_ast_node('InlineFragment', #{'directives' => '2', 'selectionSet' => '$3'}).
+
 InlineFragment -> '...' 'on' TypeCondition SelectionSet : build_ast_node('InlineFragment', #{'typeCondition' => '$3', 'selectionSet' => '$4'}).
 InlineFragment -> '...' 'on' TypeCondition Directives SelectionSet : build_ast_node('InlineFragment', #{'typeCondition' => '$3', 'directives' => '$4', 'selectionSet' => '$5'}).
 

--- a/test/graphql/execution/executor_test.exs
+++ b/test/graphql/execution/executor_test.exs
@@ -37,6 +37,19 @@ defmodule GraphQL.Execution.Executor.ExecutorTest do
     assert_execute {~S[{ greeting(name: "Elixir") }], TestSchema.schema}, %{greeting: "Hello, Elixir!"}
   end
 
+  test "anonymous fragments are processed" do
+    schema = %GraphQL.Schema{
+      query: %GraphQL.ObjectType{
+        name: "X",
+        fields: %{
+          id:   %{type: "Integer", resolve: 1},
+          name: %{type: "String", resolve: "Mark"}
+        }
+      }
+    }
+    assert_execute({"{id, ...{ name }}", schema}, %{id: 1, name: "Mark"})
+  end
+
   test "allow {module, function, args} style of resolve" do
     schema = %GraphQL.Schema{
       query: %GraphQL.ObjectType{

--- a/test/graphql/lang/parser_test.exs
+++ b/test/graphql/lang/parser_test.exs
@@ -399,7 +399,7 @@ defmodule GraphQL.Lang.Parser.ParserTest do
   end
 
   test "InlineFragment" do
-    assert_parse "{ user { name, ... on Person { age } } }",
+    assert_parse "{ user { name, ... on Person { age }, ... { id } } }",
     %{kind: :Document,
       loc: %{start: 0},
       definitions: [%{kind: :OperationDefinition,
@@ -424,7 +424,14 @@ defmodule GraphQL.Lang.Parser.ParserTest do
                                                                                                                    name: %{kind: :Name, loc: %{start: 0}, value: "age"}}]},
                                                                                     typeCondition: %{kind: :NamedType,
                                                                                                      loc: %{start: 0},
-                                                                                                     name: %{kind: :Name, loc: %{start: 0}, value: "Person"}}}]}}]}}]}
+                                                                                                     name: %{kind: :Name, loc: %{start: 0}, value: "Person"}}},
+                                                                                  %{kind: :InlineFragment,
+                                                                                    loc: %{start: 0},
+                                                                                    selectionSet: %{kind: :SelectionSet,
+                                                                                                    loc: %{start: 0},
+                                                                                                    selections: [%{kind: :Field,
+                                                                                                                   loc: %{start: 0},
+                                                                                                                   name: %{kind: :Name, loc: %{start: 0}, value: "id"}}]}}]}}]}}]}
   end
 
   test "ObjectTypeDefinition" do


### PR DESCRIPTION
Per http://facebook.github.io/graphql/#sec-Inline-Fragments, _TypeConditions_ can be optional for Inline Fragments. I found this while playing around with adding _Validations_  as a learning exercise, and felt that it may make a better first PR than the _Validations_ themselves.
