### PR TITLE
AST visitor for providing query/schema validation.

### DIFF
--- a/lib/graphql/lang/visitor.ex
+++ b/lib/graphql/lang/visitor.ex
@@ -1,0 +1,184 @@
+defmodule GraphQL.Lang.Visitor do
+  defmodule Node do
+    @kinds %{
+      Name: [],
+      Document: [:definitions],
+      OperationDefinition: [:name, :variableDefinitions, :directives, :selectionSet],
+      VariableDefinition: [:variable, :type, :defaultValue],
+      Variable: [:name],
+      SelectionSet: [:selections],
+      Field: [:alias, :name, :arguments, :directives, :selectionSet],
+      Argument: [:name, :value],
+      FragmentSpread: [:name, :directives],
+      InlineFragment: [:typeCondition, :directives, :selectionSet],
+      FragmentDefinition: [:name, :typeCondition, :directives, :selectionSet],
+      IntValue: [],
+      FloatValue: [],
+      StringValue: [],
+      BooleanValue: [],
+      EnumValue: [],
+      ListValue: [:values],
+      ObjectValue: [:fields],
+      ObjectField: [:name, :value],
+      Directive: [:name, :arguments],
+      NamedType: [:name],
+      ListType: [:type],
+      NonNullType: [:type],
+      ObjectTypeDefinition: [:name, :interfaces, :fields],
+      FieldDefinition: [:name, :arguments, :type],
+      InputValueDefinition: [:name, :type, :defaultValue],
+      InterfaceTypeDefinition: [:name, :fields],
+      UnionTypeDefinition: [:name, :types],
+      ScalarTypeDefinition: [:name],
+      EnumTypeDefinition: [:name, :values],
+      EnumValueDefinition: [:name],
+      InputObjectTypeDefinition: [:name, :fields],
+      TypeExtensionDefinition: [:definition]
+    }
+
+    def children(item) when is_map(item),  do: Dict.get(@kinds, item.kind, [])
+    def children(item) when is_list(item), do: item
+    def children(_),                       do: []
+  end
+
+  defmodule Stack do
+    defstruct ancestors: [],
+              in_list: false,
+              index: -1,
+              key: nil,
+              keys: [],
+              parent: nil,
+              path: [],
+              previous: nil
+  end
+
+  # Depth-first traversal through the tree.
+  def visit(entrypoint, visitors) when is_map(visitors) do
+    context = %{entrypoint: entrypoint, visitors: visitors}
+    stack = %Stack{keys: Node.children(entrypoint), in_list: is_list(entrypoint)}
+
+    case walk(stack, context) do
+      {:ok, result} -> {:ok, result}
+    end
+  end
+
+  defp walk(_stack = nil, context), do: {:ok, context.entrypoint}
+  defp walk(stack = %Stack{}, context) do
+    stack = %Stack{stack | index: stack.index + 1}
+    is_leaving = leaving?(stack)
+
+    {item, stack} = case is_leaving do
+      false -> enter_node(stack, context.entrypoint)
+      true  -> leave_node(stack)
+    end
+
+    apply_visitors(item, is_leaving, stack, context.visitors)
+    walk(next_node(is_leaving, item, stack), context)
+  end
+
+  defp leaving?(stack), do: stack.index === length(stack.keys)
+
+  defp next_node(true, _, stack), do: stack
+  defp next_node(_, nil, stack), do: stack
+  defp next_node(false, item, stack) when is_nil(item), do: stack
+  defp next_node(false, item, stack) do
+    ancestors = cond do
+      stack.parent -> stack.ancestors ++ [stack.parent]
+      true         -> stack.ancestors
+    end
+
+    %Stack{stack |
+      parent: item,
+      keys: Node.children(item),
+      in_list: is_list(item),
+      index: -1,
+      previous: stack,
+      ancestors: ancestors
+    }
+  end
+
+  defp enter_node(stack, entrypoint) do
+    %{parent: parent, in_list: in_list, keys: keys, index: index} = stack
+
+    {item, key} = cond do
+      not is_nil(parent) and in_list     -> {Enum.at(parent, index), index}
+      not is_nil(parent) and not in_list -> {Dict.get(parent, Enum.at(keys, index)), Enum.at(keys, index)}
+      is_nil(parent)                     -> {entrypoint, nil}
+      true                               -> {nil, nil}
+    end
+
+    path = cond do
+      parent && !is_nil(item) -> stack.path ++ [key]
+      true                    -> stack.path
+    end
+
+    {item, %Stack{stack | key: key, path: path}}
+  end
+
+  defp leave_node(_stack = %Stack{previous: nil}), do: {nil, nil}
+  defp leave_node(stack) do
+    %{ancestors: ancestors} = stack
+
+    {parent, ancestors} = cond do
+      length(ancestors) === 0 -> {nil, []}
+      true                    -> {List.last(ancestors), Enum.drop(ancestors, -1)}
+    end
+
+    {stack.parent, %Stack{stack |
+      key: List.last(stack.path),
+      path: Enum.drop(stack.path, -1),
+      parent: parent,
+      ancestors: ancestors,
+      index: stack.previous.index,
+      keys: stack.previous.keys,
+      in_list: stack.previous.in_list,
+      previous: stack.previous.previous
+    }}
+  end
+
+  defp apply_visitors(nil, _, _, _), do: nil
+  defp apply_visitors(item, is_leaving, stack, visitors) do
+    cond do
+      not is_list(item) and not is_item(item) -> throw "Invalid AST Node: #{inspect(item)}"
+      is_list(item) -> nil
+      true ->
+        case get_visitor(visitors, item.kind, is_leaving) do
+          {type, visitor} ->
+            args = stack |> Map.take([:key, :parent, :path, :ancestors]) |> Map.merge(%{item: item})
+            case visitor.(args) do
+              %{item: action} -> edit(type, action, item)
+              _               -> nil
+            end
+          nil -> nil
+        end
+    end
+  end
+
+  defp get_visitor(visitors, kind, true),  do: get_visitor(visitors, kind, :leave)
+  defp get_visitor(visitors, kind, false), do: get_visitor(visitors, kind, :enter)
+  defp get_visitor(visitors, kind, type) do
+    # TODO: this is pretty gross
+    cond do
+      Map.has_key?(visitors, kind) ->
+        name_key = Map.get(visitors, kind)
+        cond do
+          is_map(name_key)                            -> {type, Map.get(name_key, type)}  # %{Kind: type: fn()}
+          is_function(name_key, 1) and type == :enter -> {type, name_key} # %{Kind: fn()}
+          true -> nil
+        end
+      Map.has_key?(visitors, type) -> {type, get_in(visitors, [type])} # %{type: fn()}
+      true -> nil
+    end
+  end
+
+  defp is_item(item) do
+    is_map(item) and Map.has_key?(item, :kind) and is_atom(item.kind)
+  end
+
+  defp edit(type, action, item) when is_atom(type) and is_map(item), do: edit(type, action, item)
+  defp edit(:enter, :skip, _item), do: nil                                 # don't visit this item
+  defp edit(:enter, :delete, _item), do: nil                               # delete the item
+  defp edit(:enter, replacement, _item) when is_map(replacement), do: nil  # replace the item
+  defp edit(:leave, :delete, _item), do: nil                               # delete the item
+  defp edit(:leave, replacement, _item) when is_map(replacement), do: nil  # replace the item
+end

--- a/test/graphql/lang/visitor_test.exs
+++ b/test/graphql/lang/visitor_test.exs
@@ -1,0 +1,341 @@
+defmodule GraphQL.Lang.Visitor.VisitorTest do
+  use ExUnit.Case, async: true
+
+  test "traverses the tree" do
+    {:ok, doc} = GraphQL.Lang.Parser.parse("{ a, b { x }, c }")
+
+    GraphQL.Lang.Visitor.visit(doc, %{
+      enter: fn(%{item: item}) ->
+        send self, {:enter, item.kind, Dict.get(item, :value)}
+        nil
+      end,
+      leave: fn(%{item: item}) ->
+        send self, {:leave, item.kind, Dict.get(item, :value)}
+        nil
+      end
+    })
+
+    assert_received {:enter, :Document, nil}
+    assert_received {:enter, :OperationDefinition, nil}
+    assert_received {:enter, :SelectionSet, nil}
+    assert_received {:enter, :Field, nil}
+    assert_received {:enter, :Name, "a"}
+    assert_received {:leave, :Name, "a"}
+    assert_received {:leave, :Field, nil}
+    assert_received {:enter, :Field, nil}
+    assert_received {:enter, :Name, "b"}
+    assert_received {:leave, :Name, "b"}
+    assert_received {:enter, :SelectionSet, nil}
+    assert_received {:enter, :Field, nil}
+    assert_received {:enter, :Name, "x"}
+    assert_received {:leave, :Name, "x"}
+    assert_received {:leave, :Field, nil}
+    assert_received {:leave, :SelectionSet, nil}
+    assert_received {:leave, :Field, nil}
+    assert_received {:enter, :Field, nil}
+    assert_received {:enter, :Name, "c"}
+    assert_received {:leave, :Name, "c"}
+    assert_received {:leave, :Field, nil}
+    assert_received {:leave, :SelectionSet, nil}
+    assert_received {:leave, :OperationDefinition, nil}
+    assert_received {:leave, :Document, nil}
+  end
+
+  # test "editing on enter"
+  # test "editing on leave"
+  # test "skipping a sub-tree"
+  # test "early exit while entering"
+  # test "early exit while leaving"
+
+  test "named functions visitor API" do
+    {:ok, doc} = GraphQL.Lang.Parser.parse("{ a, b { x }, c }")
+
+    GraphQL.Lang.Visitor.visit(doc, %{
+      Name: fn(%{item: item}) ->
+        send self, {:enter, item.kind, Dict.get(item, :value)}
+        nil
+      end,
+      SelectionSet: %{
+        enter: fn(%{item: item}) ->
+          send self, {:enter, item.kind, Dict.get(item, :value)}
+          nil
+        end,
+        leave: fn(%{item: item}) ->
+          send self, {:leave, item.kind, Dict.get(item, :value)}
+          nil
+        end
+      }
+    })
+
+    assert_received {:enter, :SelectionSet, nil}
+    assert_received {:enter, :Name, "a"}
+    assert_received {:enter, :Name, "b"}
+    assert_received {:enter, :SelectionSet, nil}
+    assert_received {:enter, :Name, "x"}
+    assert_received {:leave, :SelectionSet, nil}
+    assert_received {:enter, :Name, "c"}
+    assert_received {:leave, :SelectionSet, nil}
+  end
+
+  test "kitchen sink" do
+    {:ok, doc} = GraphQL.Lang.Parser.parse("""
+      query queryName($foo: ComplexType, $site: Site = MOBILE) {
+        whoever123is: item(id: [123, 456]) {
+          id ,
+          ... on User @defer {
+            field2 {
+              id ,
+              alias: field1(first:10, after:$foo,) @include(if: $foo) {
+                id,
+                ...frag
+              }
+            }
+          }
+        }
+      }
+
+      mutation likeStory {
+        like(story: 123) @defer {
+          story {
+            id
+          }
+        }
+      }
+
+      fragment frag on Friend {
+        foo(size: $size, bar: $b, obj: {key: "value"})
+      }
+
+      {
+        unnamed(truthy: true, falsey: false),
+        query
+      }
+    """)
+
+    GraphQL.Lang.Visitor.visit(doc, %{
+      enter: fn(%{item: item, key: key, parent: parent}) ->
+        send self, {:enter, item.kind, key, parent && Dict.get(parent, :kind)}
+        nil
+      end,
+      leave: fn(%{item: item, key: key, parent: parent}) ->
+        send self, {:leave, item.kind, key, parent && Dict.get(parent, :kind)}
+        nil
+      end
+    })
+
+    assert_received {:enter, :Document, nil, nil}
+    assert_received {:enter, :OperationDefinition, 0, nil}
+    assert_received {:enter, :Name, :name, :OperationDefinition}
+    assert_received {:leave, :Name, :name, :OperationDefinition}
+    assert_received {:enter, :VariableDefinition, 0, nil}
+    assert_received {:enter, :Variable, :variable, :VariableDefinition}
+    assert_received {:enter, :Name, :name, :Variable}
+    assert_received {:leave, :Name, :name, :Variable}
+    assert_received {:leave, :Variable, :variable, :VariableDefinition}
+    assert_received {:enter, :NamedType, :type, :VariableDefinition}
+    assert_received {:enter, :Name, :name, :NamedType}
+    assert_received {:leave, :Name, :name, :NamedType}
+    assert_received {:leave, :NamedType, :type, :VariableDefinition}
+    assert_received {:leave, :VariableDefinition, 0, nil}
+    assert_received {:enter, :VariableDefinition, 1, nil}
+    assert_received {:enter, :Variable, :variable, :VariableDefinition}
+    assert_received {:enter, :Name, :name, :Variable}
+    assert_received {:leave, :Name, :name, :Variable}
+    assert_received {:leave, :Variable, :variable, :VariableDefinition}
+    assert_received {:enter, :NamedType, :type, :VariableDefinition}
+    assert_received {:enter, :Name, :name, :NamedType}
+    assert_received {:leave, :Name, :name, :NamedType}
+    assert_received {:leave, :NamedType, :type, :VariableDefinition}
+    assert_received {:enter, :EnumValue, :defaultValue, :VariableDefinition}
+    assert_received {:leave, :EnumValue, :defaultValue, :VariableDefinition}
+    assert_received {:leave, :VariableDefinition, 1, nil}
+    assert_received {:enter, :SelectionSet, :selectionSet, :OperationDefinition}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :alias, :Field}
+    assert_received {:leave, :Name, :alias, :Field}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:enter, :Argument, 0, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :ListValue, :value, :Argument}
+    assert_received {:enter, :IntValue, 0, nil}
+    assert_received {:leave, :IntValue, 0, nil}
+    assert_received {:enter, :IntValue, 1, nil}
+    assert_received {:leave, :IntValue, 1, nil}
+    assert_received {:leave, :ListValue, :value, :Argument}
+    assert_received {:leave, :Argument, 0, nil}
+    assert_received {:enter, :SelectionSet, :selectionSet, :Field}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:enter, :InlineFragment, 1, nil}
+    assert_received {:enter, :NamedType, :typeCondition, :InlineFragment}
+    assert_received {:enter, :Name, :name, :NamedType}
+    assert_received {:leave, :Name, :name, :NamedType}
+    assert_received {:leave, :NamedType, :typeCondition, :InlineFragment}
+    assert_received {:enter, :Directive, 0, nil}
+    assert_received {:enter, :Name, :name, :Directive}
+    assert_received {:leave, :Name, :name, :Directive}
+    assert_received {:leave, :Directive, 0, nil}
+    assert_received {:enter, :SelectionSet, :selectionSet, :InlineFragment}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:enter, :SelectionSet, :selectionSet, :Field}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:enter, :Field, 1, nil}
+    assert_received {:enter, :Name, :alias, :Field}
+    assert_received {:leave, :Name, :alias, :Field}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:enter, :Argument, 0, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :IntValue, :value, :Argument}
+    assert_received {:leave, :IntValue, :value, :Argument}
+    assert_received {:leave, :Argument, 0, nil}
+    assert_received {:enter, :Argument, 1, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :Variable, :value, :Argument}
+    assert_received {:enter, :Name, :name, :Variable}
+    assert_received {:leave, :Name, :name, :Variable}
+    assert_received {:leave, :Variable, :value, :Argument}
+    assert_received {:leave, :Argument, 1, nil}
+    assert_received {:enter, :Directive, 0, nil}
+    assert_received {:enter, :Name, :name, :Directive}
+    assert_received {:leave, :Name, :name, :Directive}
+    assert_received {:enter, :Argument, 0, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :Variable, :value, :Argument}
+    assert_received {:enter, :Name, :name, :Variable}
+    assert_received {:leave, :Name, :name, :Variable}
+    assert_received {:leave, :Variable, :value, :Argument}
+    assert_received {:leave, :Argument, 0, nil}
+    assert_received {:leave, :Directive, 0, nil}
+    assert_received {:enter, :SelectionSet, :selectionSet, :Field}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:enter, :FragmentSpread, 1, nil}
+    assert_received {:enter, :Name, :name, :FragmentSpread}
+    assert_received {:leave, :Name, :name, :FragmentSpread}
+    assert_received {:leave, :FragmentSpread, 1, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :Field}
+    assert_received {:leave, :Field, 1, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :InlineFragment}
+    assert_received {:leave, :InlineFragment, 1, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :OperationDefinition}
+    assert_received {:leave, :OperationDefinition, 0, nil}
+    assert_received {:enter, :OperationDefinition, 1, nil}
+    assert_received {:enter, :Name, :name, :OperationDefinition}
+    assert_received {:leave, :Name, :name, :OperationDefinition}
+    assert_received {:enter, :SelectionSet, :selectionSet, :OperationDefinition}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:enter, :Argument, 0, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :IntValue, :value, :Argument}
+    assert_received {:leave, :IntValue, :value, :Argument}
+    assert_received {:leave, :Argument, 0, nil}
+    assert_received {:enter, :Directive, 0, nil}
+    assert_received {:enter, :Name, :name, :Directive}
+    assert_received {:leave, :Name, :name, :Directive}
+    assert_received {:leave, :Directive, 0, nil}
+    assert_received {:enter, :SelectionSet, :selectionSet, :Field}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:enter, :SelectionSet, :selectionSet, :Field}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :Field}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :OperationDefinition}
+    assert_received {:leave, :OperationDefinition, 1, nil}
+    assert_received {:enter, :FragmentDefinition, 2, nil}
+    assert_received {:enter, :Name, :name, :FragmentDefinition}
+    assert_received {:leave, :Name, :name, :FragmentDefinition}
+    assert_received {:enter, :NamedType, :typeCondition, :FragmentDefinition}
+    assert_received {:enter, :Name, :name, :NamedType}
+    assert_received {:leave, :Name, :name, :NamedType}
+    assert_received {:leave, :NamedType, :typeCondition, :FragmentDefinition}
+    assert_received {:enter, :SelectionSet, :selectionSet, :FragmentDefinition}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:enter, :Argument, 0, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :Variable, :value, :Argument}
+    assert_received {:enter, :Name, :name, :Variable}
+    assert_received {:leave, :Name, :name, :Variable}
+    assert_received {:leave, :Variable, :value, :Argument}
+    assert_received {:leave, :Argument, 0, nil}
+    assert_received {:enter, :Argument, 1, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :Variable, :value, :Argument}
+    assert_received {:enter, :Name, :name, :Variable}
+    assert_received {:leave, :Name, :name, :Variable}
+    assert_received {:leave, :Variable, :value, :Argument}
+    assert_received {:leave, :Argument, 1, nil}
+    assert_received {:enter, :Argument, 2, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :ObjectValue, :value, :Argument}
+    assert_received {:enter, :ObjectField, 0, nil}
+    assert_received {:enter, :Name, :name, :ObjectField}
+    assert_received {:leave, :Name, :name, :ObjectField}
+    assert_received {:enter, :StringValue, :value, :ObjectField}
+    assert_received {:leave, :StringValue, :value, :ObjectField}
+    assert_received {:leave, :ObjectField, 0, nil}
+    assert_received {:leave, :ObjectValue, :value, :Argument}
+    assert_received {:leave, :Argument, 2, nil}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :FragmentDefinition}
+    assert_received {:leave, :FragmentDefinition, 2, nil}
+    assert_received {:enter, :OperationDefinition, 3, nil}
+    assert_received {:enter, :SelectionSet, :selectionSet, :OperationDefinition}
+    assert_received {:enter, :Field, 0, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:enter, :Argument, 0, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :BooleanValue, :value, :Argument}
+    assert_received {:leave, :BooleanValue, :value, :Argument}
+    assert_received {:leave, :Argument, 0, nil}
+    assert_received {:enter, :Argument, 1, nil}
+    assert_received {:enter, :Name, :name, :Argument}
+    assert_received {:leave, :Name, :name, :Argument}
+    assert_received {:enter, :BooleanValue, :value, :Argument}
+    assert_received {:leave, :BooleanValue, :value, :Argument}
+    assert_received {:leave, :Argument, 1, nil}
+    assert_received {:leave, :Field, 0, nil}
+    assert_received {:enter, :Field, 1, nil}
+    assert_received {:enter, :Name, :name, :Field}
+    assert_received {:leave, :Name, :name, :Field}
+    assert_received {:leave, :Field, 1, nil}
+    assert_received {:leave, :SelectionSet, :selectionSet, :OperationDefinition}
+    assert_received {:leave, :OperationDefinition, 3, nil}
+    assert_received {:leave, :Document, nil, nil}
+  end
+end


### PR DESCRIPTION
An incremental PR working towards implementing validation (#35).

This PR introduces a visitor module which provides a way of traversing and visiting a query document via depth-first traversal.

This visitor module is currently not actually used anywhere, but will be important for implementing validation down the track.
