### PR TITLE
Enforce TypeConditions on Fragments

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -184,7 +184,6 @@ defmodule GraphQL.Execution.Executor do
   end
 
   defp collect_fragment(context, runtime_type, selection, field_fragment_map) do
-    # TODO: should_include?(context, selection.directives)
     condition_matches = typecondition_matches?(selection, runtime_type)
     if condition_matches do
       collect_fields(context, runtime_type, selection.selectionSet, field_fragment_map)

--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -68,12 +68,12 @@ defmodule GraphQL.Execution.Executor do
       case selection do
         %{kind: :Field} -> put_in(field_fragment_map.fields[field_entry_key(selection)], [selection])
         %{kind: :InlineFragment} ->
-          collect_fields(context, runtime_type, selection.selectionSet, field_fragment_map)
+          collect_fragment(context, runtime_type, selection, field_fragment_map)
         %{kind: :FragmentSpread} ->
           fragment_name = selection.name.value
           if !field_fragment_map.fragments[fragment_name] do
             field_fragment_map = put_in(field_fragment_map.fragments[fragment_name], true)
-            collect_fields(context, runtime_type, context.fragments[fragment_name].selectionSet, field_fragment_map)
+            collect_fragment(context, runtime_type, context.fragments[fragment_name], field_fragment_map)
           else
             field_fragment_map
           end
@@ -181,5 +181,24 @@ defmodule GraphQL.Execution.Executor do
 
   defp field_entry_key(field) do
     Map.get(field, :alias, field.name)
+  end
+
+  defp collect_fragment(context, runtime_type, selection, field_fragment_map) do
+    # TODO: should_include?(context, selection.directives)
+    condition_matches = typecondition_matches?(selection, runtime_type)
+    if condition_matches do
+      collect_fields(context, runtime_type, selection.selectionSet, field_fragment_map)
+    else
+      field_fragment_map
+    end
+  end
+
+  defp typecondition_matches?(selection, runtime_type) do
+    type = Map.get(selection, :typeCondition, :no_type)
+    cond do
+      type == :no_type -> true
+      type.name.value === runtime_type.name -> true
+      true -> false
+    end
   end
 end

--- a/test/graphql/execution/executor_test.exs
+++ b/test/graphql/execution/executor_test.exs
@@ -50,7 +50,7 @@ defmodule GraphQL.Execution.Executor.ExecutorTest do
     assert_execute({"{id, ...{ name }}", schema}, %{id: 1, name: "Mark"})
   end
 
-  test "TypeChecked fragments run the correct type" do
+  test "TypeChecked inline fragments run the correct type" do
     schema = %GraphQL.Schema{
       query: %GraphQL.ObjectType{
         name: "BType",
@@ -63,6 +63,21 @@ defmodule GraphQL.Execution.Executor.ExecutorTest do
     }
     assert_execute({"{id, ... on AType { a }, ... on BType { b }}", schema}, %{id: 1, b: "b"})
   end
+
+  test "TypeChecked fragments run the correct type" do
+    schema = %GraphQL.Schema{
+      query: %GraphQL.ObjectType{
+        name: "BType",
+        fields: %{
+          id:   %{type: "Integer", resolve: 1},
+          a: %{type: "String", resolve: "a"},
+          b: %{type: "String", resolve: "b"}
+        }
+      }
+    }
+    assert_execute({"{id, ...spreada ...spreadb} fragment spreadb on BType { b } fragment spreada on AType { a }", schema}, %{id: 1, b: "b"})
+  end
+
 
   test "allow {module, function, args} style of resolve" do
     schema = %GraphQL.Schema{

--- a/test/graphql/execution/executor_test.exs
+++ b/test/graphql/execution/executor_test.exs
@@ -50,6 +50,20 @@ defmodule GraphQL.Execution.Executor.ExecutorTest do
     assert_execute({"{id, ...{ name }}", schema}, %{id: 1, name: "Mark"})
   end
 
+  test "TypeChecked fragments run the correct type" do
+    schema = %GraphQL.Schema{
+      query: %GraphQL.ObjectType{
+        name: "BType",
+        fields: %{
+          id:   %{type: "Integer", resolve: 1},
+          a: %{type: "String", resolve: "a"},
+          b: %{type: "String", resolve: "b"}
+        }
+      }
+    }
+    assert_execute({"{id, ... on AType { a }, ... on BType { b }}", schema}, %{id: 1, b: "b"})
+  end
+
   test "allow {module, function, args} style of resolve" do
     schema = %GraphQL.Schema{
       query: %GraphQL.ObjectType{


### PR DESCRIPTION
Prior to this, all fragments would be evaluated, regardless of if they had a TypeCondition that matched the object type. I broke out the `collect_fragment` to keep the `collect_fields` function from bloating more, as I'm also planning on trying to add support for Directives in the Executor soon if this gets merged.
