### PR TITLE
Support recursive schema references by allowing quoted fields

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -156,9 +156,15 @@ defmodule GraphQL.Execution.Executor do
     end
   end
 
+  defp maybe_unwrap(item) when is_tuple(item) do
+    {result,_} = Code.eval_quoted(item)
+    result
+  end
+  defp maybe_unwrap(item), do: item
+
   defp field_definition(_schema, parent_type, field_name) do
     # TODO deal with introspection
-    parent_type.fields[field_name]
+    maybe_unwrap(parent_type.fields)[field_name]
   end
 
   defp argument_values(arg_defs, arg_asts, variable_values) do


### PR DESCRIPTION
As reported in Issue #38, Schemas weren't able to recursively refer to one another. By quoting the offending references and only evaling them during Execution, we can resolve everything on-demand. The JS reference implementation does something similar where it allows `field` (and everything else, maybe?) to be wrapped in an anonymous function that's run if necessary (https://github.com/graphql/graphql-js/blob/568dc52a4f9cc9bdec4f9283e6e528970af06cde/src/type/definition.js#L331)

If you remove the `quote do` from the tests, you should end up with an infinite loop. I also tested this a bit deeper by having it basically do `b { name, b { name, b { ... } }}` a few dozen times, and it worked ok. I settled on the test I wrote as a sort of readable version that goes across two schemas.
