### PR TITLE
Initial Work for adding Types (Enum, Interface, Int, Float, String, Boolean)

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -136,6 +136,12 @@ defmodule GraphQL.Execution.Executor do
     execute_fields(context, return_type, result, sub_field_asts.fields)
   end
 
+  defp complete_value(context, %GraphQL.Type.Interface{} = return_type, field_asts, _info, result) do
+    runtime_type = GraphQL.Type.Interface.get_object_type(return_type, result)
+    sub_field_asts = collect_sub_fields(context, runtime_type, field_asts)
+    execute_fields(context, runtime_type, result, sub_field_asts.fields)
+  end
+
   defp complete_value(context, %GraphQL.List{of_type: list_type}, field_asts, info, result) do
     Enum.map result, fn(item) ->
       complete_value_catching_error(context, list_type, field_asts, info, item)

--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -142,8 +142,8 @@ defmodule GraphQL.Execution.Executor do
     end
   end
 
-  defp complete_value(_context, _return_type, _field_asts, _info, result) do
-    result
+  defp complete_value(_context, return_type, _field_asts, _info, result) do
+    GraphQL.Types.serialize(return_type, result)
   end
 
   defp collect_sub_fields(context, return_type, field_asts) do
@@ -181,8 +181,8 @@ defmodule GraphQL.Execution.Executor do
     end
   end
 
-  defp value_from_ast(value_ast, _type, _variable_values) do
-    value_ast.value.value
+  defp value_from_ast(value_ast, type, _variable_values) do
+    GraphQL.Types.parse_value(type.type, value_ast.value.value)
   end
 
   defp field_entry_key(field) do

--- a/lib/graphql/type/boolean.ex
+++ b/lib/graphql/type/boolean.ex
@@ -1,0 +1,12 @@
+defmodule GraphQL.Type.Boolean do
+  defstruct name: "Boolean", description: ":words:"
+
+  def coerce(""), do: false
+  def coerce(0), do: false
+  def coerce(value), do: !!value
+end
+
+defimpl GraphQL.Types, for: GraphQL.Type.Boolean do
+  def parse_value(_, value), do: GraphQL.Type.Boolean.coerce(value)
+  def serialize(_, value), do: GraphQL.Type.Boolean.coerce(value)
+end

--- a/lib/graphql/type/definition.ex
+++ b/lib/graphql/type/definition.ex
@@ -10,7 +10,7 @@ defimpl GraphQL.Types, for: Any do
 end
 
 defmodule GraphQL.ObjectType do
-  defstruct name: "", description: "", fields: %{}
+  defstruct name: "", description: "", fields: %{}, interfaces: []
 end
 
 defmodule GraphQL.List do

--- a/lib/graphql/type/definition.ex
+++ b/lib/graphql/type/definition.ex
@@ -1,3 +1,14 @@
+defprotocol GraphQL.Types do
+  @fallback_to_any true
+  def parse_value(_,_)
+  def serialize(_,_)
+end
+
+defimpl GraphQL.Types, for: Any do
+  def parse_value(_,v), do:  v
+  def serialize(_,v), do: v
+end
+
 defmodule GraphQL.ObjectType do
   defstruct name: "", description: "", fields: %{}
 end

--- a/lib/graphql/type/enum.ex
+++ b/lib/graphql/type/enum.ex
@@ -1,0 +1,40 @@
+defmodule GraphQL.Type.EnumValue do
+  defstruct name: "", value: "", description: ""
+end
+
+defmodule GraphQL.Type.Enum do
+  defstruct name: "", values: %{}, description: ""
+
+  def new(map) do
+    map = %{map | values: define_values(map.values)}
+    struct(GraphQL.Type.Enum, map)
+  end
+
+  def values(map) do
+    Enum.reduce(map.values, %{}, fn(%{name: name, value: value}, acc) ->
+      Map.put(acc, name, value)
+    end)
+  end
+
+  defp define_values(values) do
+    Enum.map(values, fn {name,v} ->
+      val = Dict.get(v, :value, name)
+      desc = Dict.get(v, :description, "")
+      %GraphQL.Type.EnumValue{name: name, value: val, description: desc}
+    end)
+  end
+end
+
+defimpl GraphQL.Types, for: GraphQL.Type.Enum do
+  def parse_value(struct, value) do
+    GraphQL.Type.Enum.values(struct) |> Map.get(String.to_atom(value))
+  end
+
+  def serialize(struct, wanted) do
+    values = GraphQL.Type.Enum.values(struct)
+    case Enum.find(values, fn({_,v}) -> v == wanted end) do
+      nil -> nil
+      {name, _} -> to_string(name)
+    end
+  end
+end

--- a/lib/graphql/type/float.ex
+++ b/lib/graphql/type/float.ex
@@ -1,0 +1,20 @@
+defmodule GraphQL.Type.Float do
+  defstruct name: "Float", description: "IEEE Floating point"
+
+  def coerce(value) when is_binary(value) do
+    case Float.parse(value) do
+      :error -> nil
+      {found,_} -> coerce(found)
+    end
+  end
+  def coerce(false), do: 0
+  def coerce(true), do: 1
+  def coerce(value) do
+    value = value * 1.0
+  end
+end
+
+defimpl GraphQL.Types, for: GraphQL.Type.Float do
+  def parse_value(_, value), do: GraphQL.Type.Float.coerce(value)
+  def serialize(_, value), do: GraphQL.Type.Float.coerce(value)
+end

--- a/lib/graphql/type/int.ex
+++ b/lib/graphql/type/int.ex
@@ -1,0 +1,28 @@
+defmodule GraphQL.Type.Int do
+  @max_int 2147483647
+  @min_int -2147483648
+
+  defstruct name: "Int", description: "Blah blah -(2^53-1) and 2^53 - 1"
+
+  def coerce(value) when is_binary(value) do
+    case Float.parse(value) do
+      :error -> nil
+      {found,_} -> coerce(found)
+    end
+  end
+  def coerce(false), do: 0
+  def coerce(true), do: 1
+  def coerce(value) do
+    value = value * 1.0
+    if(value <= @max_int && value >= @min_int) do
+      if(value < 0, do: &Float.ceil/2, else: &Float.floor/2).(value, 0) |> round
+    else
+      nil
+    end
+  end
+end
+
+defimpl GraphQL.Types, for: GraphQL.Type.Int do
+  def parse_value(_, value), do: GraphQL.Type.Int.coerce(value)
+  def serialize(_, value), do: GraphQL.Type.Int.coerce(value)
+end

--- a/lib/graphql/type/interface.ex
+++ b/lib/graphql/type/interface.ex
@@ -1,0 +1,11 @@
+defmodule GraphQL.Type.Interface do
+  defstruct name: "", description: "", fields: %{}, resolver: nil
+
+  def new(map) do
+    struct(GraphQL.Type.Interface, map)
+  end
+
+  def get_object_type(interface, object) do
+    interface.resolver.(object)
+  end
+end

--- a/lib/graphql/type/string.ex
+++ b/lib/graphql/type/string.ex
@@ -1,0 +1,10 @@
+defmodule GraphQL.Type.String do
+  defstruct name: "String", description: ":words:"
+
+  def coerce(value), do: to_string(value)
+end
+
+defimpl GraphQL.Types, for: GraphQL.Type.String do
+  def parse_value(_, value), do: GraphQL.Type.String.coerce(value)
+  def serialize(_, value), do: GraphQL.Type.String.coerce(value)
+end

--- a/test/graphql/type/enum_test.exs
+++ b/test/graphql/type/enum_test.exs
@@ -1,0 +1,119 @@
+defmodule GraphQL.Lang.Type.EnumTest do
+  use ExUnit.Case, async: true
+  import ExUnit.TestHelpers
+
+  defmodule TestSchema do
+    def color_type do
+      %{
+        name: "Color",
+        values: %{
+          "RED": %{value: 0},
+          "GREEN": %{value: 1},
+          "BLUE": %{value: 2}
+        }
+      } |>  GraphQL.Type.Enum.new
+    end
+
+    # GraphQL.Type.ScalarType -> GraphQL.Type.Int when it's added
+    def query do
+      %GraphQL.ObjectType{
+          name: "Query",
+          fields: %{
+            color_enum: %{
+              type: color_type,
+              args: %{
+                from_enum: %{type: color_type},
+                from_int: %{type: GraphQL.Type.ScalarType},
+                from_string: %{type: GraphQL.Type.string},
+              },
+              resolve: fn(_, args, _) ->
+                Dict.get(args, :from_enum, nil) ||
+                Dict.get(args, :from_int, nil) ||
+                Dict.get(args, :from_string, nil)
+              end
+            },
+            color_int: %{
+              type: GraphQL.Type.ScalarType,
+              args: %{
+                from_enum: %{type: color_type},
+                from_int: %{type: GraphQL.Type.ScalarType}
+              },
+              resolve: fn(_, args, _) ->
+                Dict.get(args, :from_enum, nil) ||
+                Dict.get(args, :from_int, nil)
+              end
+            }
+          }
+        }
+    end
+
+    def schema, do: %GraphQL.Schema{ query: query }
+  end
+
+  test "enum values are able to be parsed" do
+    assert 1 == GraphQL.Types.parse_value(TestSchema.color_type, "GREEN")
+  end
+
+  test "enum values are able to be serialized" do
+    assert "GREEN" == GraphQL.Types.serialize(TestSchema.color_type, 1)
+  end
+
+  test "accepts enum literals as input" do
+    assert_execute {"{ color_int(from_enum: GREEN) }", TestSchema.schema}, %{color_int: 1}
+  end
+
+  test "enum may be output type" do
+    assert_execute {"{ color_enum(from_int: 1) }", TestSchema.schema}, %{color_enum: "GREEN"}
+  end
+
+  test "enum may be both input and output type" do
+    assert_execute({"{ color_enum(from_enum: GREEN) }", TestSchema.schema}, %{color_enum: "GREEN"})
+  end
+
+  @tag :skip # needs type validation
+  test "does not accept string literals" do
+    assert_execute({~S[{ color_enum(from_enum: "GREEN") }], TestSchema.schema}, "should return an argument error")
+  end
+
+  @tag :skip # needs to allow nils to be returned
+  test "does not accept incorrect internal value" do
+   assert_execute({~S[{ color_enum(from_string: "GREEN") }], TestSchema.schema}, %{color_enum: nil})
+  end
+
+  @tag :skip # needs type validation
+  test "does not accept internal value in place of enum literal" do
+    assert_execute({"{ color_enum(from_enum: 1) }", TestSchema.schema}, "should return an argument error")
+  end
+
+  @tag :skip # needs type validation
+  test "does not accept enum literal in place of int" do
+    assert_execute({"{ color_enum(from_int: GREEN) }", TestSchema.schema}, "should return an argument error")
+  end
+
+  @tag :skip # needs variable to be bound at some point
+  test "accepts JSON string as enum variable" do
+    query = "query test($color: Color!) { color_enum(from_enum: $color) }"
+    assert_execute({query, TestSchema.schema, %{color: "BLUE"}}, "failed")
+  end
+
+  @tag :skip
+  test "accepts enum literals as input arguments to mutations", do: :skipped
+  @tag :skip
+  test "accepts enum literals as input arguments to subscriptions", do: :skipped
+  @tag :skip
+  test "does not accept internal value as enum variable", do: :skipped
+  @tag :skip
+  test "does not accept string variables as enum input", do: :skipped
+  @tag :skip
+  test "does not accept internal value variable as enum input", do: :skipped
+
+  test "enum value may have an internal value of 0" do
+    assert_execute({"{ color_enum(from_enum: RED), color_int(from_enum: RED) }", TestSchema.schema}, %{color_enum: "RED", color_int: 0})
+  end
+
+  @tag :skip # needs to allow nils to be returned
+  test "enum inputs may be nullable" do
+    assert_execute({"{color_enum, color_int}", TestSchema.schema}, %{color_enum: nil, color_int: nil})
+  end
+
+end

--- a/test/graphql/type/serialization_test.exs
+++ b/test/graphql/type/serialization_test.exs
@@ -1,0 +1,22 @@
+defmodule GraphQL.Lang.Type.SerializationTest do
+  use ExUnit.Case, async: true
+  import GraphQL.Types
+
+  test "serializes output int" do
+    assert 1 == serialize(%GraphQL.Type.Int{}, 1)
+    assert 0 == serialize(%GraphQL.Type.Int{}, 0)
+    assert -1 == serialize(%GraphQL.Type.Int{}, -1)
+    assert 0 == serialize(%GraphQL.Type.Int{}, 0.1)
+    assert 1 == serialize(%GraphQL.Type.Int{}, 1.1)
+    assert -1 == serialize(%GraphQL.Type.Int{}, -1.1)
+    #assert 100000 == serialize(%GraphQL.Type.Int{}, 1e5)
+    assert nil == serialize(%GraphQL.Type.Int{}, 9876504321)
+    assert nil == serialize(%GraphQL.Type.Int{}, -9876504321)
+    #assert nil == serialize(%GraphQL.Type.Int{}, 1e100)
+    #assert nil == serialize(%GraphQL.Type.Int{}, -1e100)
+    assert -1 == serialize(%GraphQL.Type.Int{}, "-1.1")
+    assert nil == serialize(%GraphQL.Type.Int{}, "one")
+    assert 0 == serialize(%GraphQL.Type.Int{}, false)
+    assert 1 == serialize(%GraphQL.Type.Int{}, true)
+  end
+end

--- a/test/graphql/type/serialization_test.exs
+++ b/test/graphql/type/serialization_test.exs
@@ -19,4 +19,17 @@ defmodule GraphQL.Lang.Type.SerializationTest do
     assert 0 == serialize(%GraphQL.Type.Int{}, false)
     assert 1 == serialize(%GraphQL.Type.Int{}, true)
   end
+
+  test "serializes output float" do
+    assert 1.0 == serialize(%GraphQL.Type.Float{}, 1)
+    assert 0.0 == serialize(%GraphQL.Type.Float{}, 0)
+    assert -1.0 == serialize(%GraphQL.Type.Float{}, -1)
+    assert 0.1 == serialize(%GraphQL.Type.Float{}, 0.1)
+    assert 1.1 == serialize(%GraphQL.Type.Float{}, 1.1)
+    assert -1.1 == serialize(%GraphQL.Type.Float{}, -1.1)
+    assert -1.1 == serialize(%GraphQL.Type.Float{}, "-1.1")
+    assert nil == serialize(%GraphQL.Type.Float{}, "one")
+    assert 0.0 == serialize(%GraphQL.Type.Float{}, false)
+    assert 1.0 == serialize(%GraphQL.Type.Float{}, true)
+  end
 end

--- a/test/graphql/type/serialization_test.exs
+++ b/test/graphql/type/serialization_test.exs
@@ -32,4 +32,12 @@ defmodule GraphQL.Lang.Type.SerializationTest do
     assert 0.0 == serialize(%GraphQL.Type.Float{}, false)
     assert 1.0 == serialize(%GraphQL.Type.Float{}, true)
   end
+
+  test "serializes output strings" do
+    assert "string" == serialize(%GraphQL.Type.String{}, "string")
+    assert "1" == serialize(%GraphQL.Type.String{}, 1)
+    assert "-1.1" == serialize(%GraphQL.Type.String{}, -1.1)
+    assert "true" == serialize(%GraphQL.Type.String{}, true)
+    assert "false" == serialize(%GraphQL.Type.String{}, false)
+  end
 end

--- a/test/graphql/type/serialization_test.exs
+++ b/test/graphql/type/serialization_test.exs
@@ -40,4 +40,13 @@ defmodule GraphQL.Lang.Type.SerializationTest do
     assert "true" == serialize(%GraphQL.Type.String{}, true)
     assert "false" == serialize(%GraphQL.Type.String{}, false)
   end
+
+  test "serializes output boolean" do
+    assert true == serialize(%GraphQL.Type.Boolean{}, "string")
+    assert false == serialize(%GraphQL.Type.Boolean{}, "")
+    assert true == serialize(%GraphQL.Type.Boolean{}, 1)
+    assert false == serialize(%GraphQL.Type.Boolean{}, 0)
+    assert true == serialize(%GraphQL.Type.Boolean{}, true)
+    assert false == serialize(%GraphQL.Type.Boolean{}, false)
+  end
 end

--- a/test/star_wars/query_test.exs
+++ b/test/star_wars/query_test.exs
@@ -1,0 +1,90 @@
+Code.require_file "../support/star_wars/data.exs", __DIR__
+Code.require_file "../support/star_wars/schema.exs", __DIR__
+
+defmodule GraphQL.StarWars.QueryTest do
+  use ExUnit.Case, async: true
+  import ExUnit.TestHelpers
+
+  alias GraphQL.Lang.Parser
+  alias GraphQL.Execution.Executor
+
+  test "correctly identifies R2-D2 as the hero of the Star Wars Saga" do
+    query = ~S[ query hero_name_query { hero { name } }]
+    assert_execute({query, StarWars.Schema.schema}, %{hero: %{name: "R2-D2"}})
+  end
+
+  test "Allows us to query for the ID and friends of R2-D2" do
+    query = ~S[
+      query hero_and_friends_query {
+        hero { id, name, friends { name }}
+      }
+    ]
+    assert_execute({query, StarWars.Schema.schema}, %{hero: %{friends: [%{name: "Luke Skywalker"}, %{name: "Han Solo"}, %{name: "Leia Organa"}], id: "2001", name: "R2-D2"}})
+  end
+
+  test "Allows us to query for the friends of friends of R2-D2" do
+    query = ~S[
+      query nested_query {
+        hero {
+          name,
+          friends {
+            name,
+            appears_in,
+            friends {
+              name
+            }
+          }
+        }
+      }
+    ]
+    assert_execute({query, StarWars.Schema.schema}, %{hero:
+      %{name: "R2-D2",
+        friends: [
+        %{appears_in: ["NEWHOPE", "EMPIRE", "JEDI"],
+          friends: [%{name: "Han Solo"}, %{name: "Leia Organa"}, %{name: "C-3PO"}, %{name: "R2-D2"}],
+          name: "Luke Skywalker"},
+        %{appears_in: ["NEWHOPE", "EMPIRE", "JEDI"],
+          friends: [%{name: "Luke Skywalker"}, %{name: "Leia Organa"}, %{name: "R2-D2"}],
+          name: "Han Solo"},
+        %{appears_in: ["NEWHOPE", "EMPIRE", "JEDI"],
+          friends: [%{name: "Luke Skywalker"}, %{name: "Han Solo"}, %{name: "C-3PO"}, %{name: "R2-D2"}],
+          name: "Leia Organa"}],
+      }})
+  end
+
+  test "Allows us to query for Luke Skywalker directly, using his ID" do
+    query = ~S[query find_luke { human(id: "1000") { name } } ] # would have been useful for Episode VII
+     assert_execute({query, StarWars.Schema.schema}, %{human: %{name: "Luke Skywalker"}})
+  end
+
+  @tag :skip # needs variables to work
+  test "Allows us to create a generic query, then use it to fetch Luke Skywalker using his ID" do
+    query = ~S[query fetch_id($some_id: String!) { human(id: $some_id) { name }}]
+    assert_execute({query, StarWars.Schema.schema, %{some_id: "1000"}}, %{human: %{name: "Luke Skywalker"}})
+  end
+
+  @tag :skip # needs variables to work
+  test "Allows us to create a generic query, then use it to fetch Han Solo using his ID" do
+    query = ~S[query fetch_some_id($some_id: String!) { human(id: $some_id) { name }}]
+    assert_execute({query, StarWars.Schema.schema, %{some_id: "1002"}}, %{human: %{name: "Han Solo"}})
+  end
+
+  @tag :skip # needs variables to work
+  test "Allows us to create a generic query, then pass an invalid ID to get null back" do
+    query = ~S[query human_query($id: String!) { human(id: $id) { name }}]
+    assert_execute({query, StarWars.Schema.schema, %{id: "invalid id"}}, %{human: nil})
+  end
+
+  test "Allows us to query for Luke, changing his key with an alias" do
+    query = ~S[query fetch_luke_aliased { luke: human(id: "1000") { name }}]
+    assert_execute({query, StarWars.Schema.schema}, %{luke: %{name: "Luke Skywalker"}})
+  end
+
+  test "Allows us to query for both Luke and Leia, using two root fields and an alias" do
+    query = ~S[query fetch_luke_and_leia_aliased {
+      luke: human(id: "1000") { name },
+      leia: human(id: "1003") { name }
+    }]
+    assert_execute({query, StarWars.Schema.schema}, %{leia: %{name: "Leia Organa"}, luke: %{name: "Luke Skywalker"}})
+  end
+end

--- a/test/star_wars/query_test.exs
+++ b/test/star_wars/query_test.exs
@@ -87,4 +87,53 @@ defmodule GraphQL.StarWars.QueryTest do
     }]
     assert_execute({query, StarWars.Schema.schema}, %{leia: %{name: "Leia Organa"}, luke: %{name: "Luke Skywalker"}})
   end
+
+  test "Allows us to query using duplicated content" do
+    query = ~S[
+      query duplicate_fields {
+        luke: human(id: "1000") { name, home_planet },
+        leia: human(id: "1003") { name, home_planet },
+      }
+    ]
+    assert_execute({query, StarWars.Schema.schema}, %{leia: %{home_planet: "Alderaan", name: "Leia Organa"}, luke: %{home_planet: "Tatooine", name: "Luke Skywalker"}})
+  end
+
+  test "Allows us to use a fragment to avoid duplicating content" do
+    query = ~S[
+      query duplicate_fields {
+        luke: human(id: "1000") { ...human_fragment },
+        leia: human(id: "1003") { ...human_fragment },
+      }
+      fragment human_fragment on Human {
+        name, home_planet
+      }
+    ]
+    assert_execute({query, StarWars.Schema.schema}, %{leia: %{home_planet: "Alderaan", name: "Leia Organa"}, luke: %{home_planet: "Tatooine", name: "Luke Skywalker"}})
+  end
+
+  @tag :skip #need __typename introspection
+  test "Allows us to verify that R2-D2 is a droid" do
+    query = ~S[
+      query check_type_of_r2d2 {
+        hero {
+          __typename
+          name
+        }
+      }
+    ]
+    assert_execute({query, StarWars.Schema.schema}, %{hero: %{name: "R2-D2", "__typename": "Droid"}})
+  end
+
+  @tag :skip #need __typename introspection
+  test "Allows us to verify that Luke is a human" do
+    query = ~S[
+      query check_type_of_luke {
+        hero(episode: EMPIRE) {
+          __typename
+          name
+        }
+      }
+    ]
+    assert_execute({query, StarWars.Schema.schema}, %{hero: %{name: "Luke Skywalker", "__typename": "Human"}})
+  end
 end

--- a/test/support/star_wars/data.exs
+++ b/test/support/star_wars/data.exs
@@ -1,0 +1,85 @@
+defmodule StarWars.Data do
+  def get_character(id) do
+    get_human(id) || get_droid(id)
+  end
+
+  def get_human(id) do
+    Map.get(human_data, String.to_atom(id), nil)
+  end
+
+  def get_droid(id) do
+    Map.get(droid_data, String.to_atom(id), nil)
+  end
+
+  def get_friends(character) do
+    Map.get(character, :friends)
+    |> Enum.map(&(get_character(&1)))
+  end
+
+  def get_hero(5), do: luke
+  def get_hero(_), do: artoo
+  def get_hero, do: artoo
+
+  def luke do
+    %{id: "1000",
+      name: "Luke Skywalker",
+      friends: ["1002", "1003", "2000", "2001"],
+      appears_in: [4,5,6],
+      home_planet: "Tatooine"}
+  end
+
+  def vader do
+    %{id: "1001",
+      name: "Darth Vader",
+      friends: ["1004"],
+      appears_in: [4,5,6],
+      home_planet: "Tatooine"}
+  end
+
+  def han do
+    %{id: "1002",
+      name: "Han Solo",
+      friends: ["1000", "1003", "2001"],
+      appears_in: [4,5,6]}
+  end
+
+  def leia do
+    %{id: "1003",
+      name: "Leia Organa",
+      friends: ["1000", "1002", "2000", "2001"],
+      appears_in: [4,5,6],
+      home_planet: "Alderaan"}
+  end
+
+  def tarkin do
+    %{id: "1004",
+      name: "Wilhuff Tarkin",
+      friends: ["1001"],
+      appears_in: [4]}
+  end
+
+  def human_data do
+    %{"1000": luke, "1001": vader, "1002": han,
+      "1003": leia, "1004": tarkin}
+  end
+
+  def threepio do
+    %{id: "2000",
+      name: "C-3PO",
+      friends: ["1000", "1002", "1003", "2001"],
+      appears_in: [4,5,6],
+      primary_function: "Protocol"}
+  end
+
+  def artoo do
+    %{id: "2001",
+      name: "R2-D2",
+      friends: ["1000", "1002", "1003"],
+      appears_in: [4,5,6],
+      primary_function: "Astromech"}
+  end
+
+  def droid_data do
+    %{"2000": threepio, "2001": artoo}
+  end
+end

--- a/test/support/star_wars/schema.exs
+++ b/test/support/star_wars/schema.exs
@@ -1,0 +1,102 @@
+defmodule StarWars.Schema do
+  import StarWars.Data
+
+  def episode_enum do
+    %{
+      name: "Episode",
+      description: "One of the films in the Star Wars Trilogy",
+      values: %{
+        NEWHOPE: %{value: 4, description: "Released in 1977"},
+        EMPIRE: %{value: 5, description: "Released in 1980"},
+        JEDI: %{value: 6, description: "Released in 1983"}
+      }
+    } |>  GraphQL.Type.Enum.new
+  end
+
+  def character_interface do
+    %{
+      name: "Character",
+      description: "A character in the Star Wars Trilogy",
+      fields: quote do %{
+        id: %{ type: "String" },
+        name: %{ type: "String" },
+        friends: %{ type: %GraphQL.List{of_type: StarWars.Schema.character_interface} },
+        appears_in: %{ type: %GraphQL.List{of_type: StarWars.Schema.episode_enum} }
+      } end,
+      resolver: fn(x) ->
+        if StarWars.Data.get_human(x.id), do: StarWars.Schema.human_type, else: StarWars.Schema.droid_type
+      end
+    } |> GraphQL.Type.Interface.new
+  end
+
+  def human_type do
+    %GraphQL.ObjectType{
+      name: "Human",
+      description: "A humanoid creature in the Star Wars universe",
+      fields: %{
+        id: %{ type: "String" },
+        name: %{ type: "String" },
+        friends: %{
+          type: %GraphQL.List{of_type: character_interface},
+          resolve: fn(item, _, _) -> StarWars.Data.get_friends(item) end
+        },
+        appears_in: %{ type: %GraphQL.List{of_type: episode_enum} },
+        home_planet: %{type: "String" }
+      },
+      interfaces: [ StarWars.Schema.character_interface ]
+    }
+  end
+
+  def droid_type do
+    %GraphQL.ObjectType{
+      name: "Droid",
+      description: "A mechanical creature in the Star Wars universe",
+      fields: %{
+        id: %{ type: "String" },
+        name: %{ type: "String" },
+        friends: %{
+          type: %GraphQL.List{of_type: character_interface},
+          resolve: fn(item, _, _) -> StarWars.Data.get_friends(item) end
+        },
+        appears_in: %{ type: %GraphQL.List{of_type: episode_enum} },
+        primary_function: %{type: "String" }
+      },
+      interfaces: [ character_interface ]
+    }
+  end
+
+  def query do
+    %GraphQL.ObjectType{
+      name: "Query",
+      fields: %{
+        hero: %{
+          type: character_interface,
+          args: %{
+            episode: %{ type: episode_enum, description: "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode" }
+          },
+          resolve: fn(o, args, rest) ->
+            StarWars.Data.get_hero(Dict.get(args, :episode, nil))
+          end
+        },
+        human: %{
+          type: human_type,
+          args: %{
+            id: %{ type: "String" }
+          },
+          resolve: fn(_, args, _) -> StarWars.Data.get_human(args.id) end
+        },
+        droid: %{
+          type: droid_type,
+          args: %{
+            id: %{ type: "String" }
+          },
+          resolve: fn(_, args, _) -> StarWars.Data.get_droid(args.id) end
+        },
+      }
+    }
+  end
+
+  def schema do
+    %GraphQL.Schema{ query: query }
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start()
+ExUnit.start(exclude: [:skip])
 
 defmodule ExUnit.TestHelpers do
   import ExUnit.Assertions
@@ -24,7 +24,7 @@ defmodule ExUnit.TestHelpers do
     {:ok, doc} = Parser.parse(query)
     assert Executor.execute(schema, doc) == {:error, expected_output}
   end
-  
+
   def assert_execute_error({query, schema, data}, expected_output) do
     {:ok, doc} = Parser.parse(query)
     assert Executor.execute(schema, doc, data) == {:error, expected_output}


### PR DESCRIPTION
This commit starts work on adding more complex types beyond simple scalars, allowing conversion from input to output. It adds a protocol, `GraphQL.Types`, to hold the parsing and serialization logic for each type, which the default being to just return whatever the input was.

All tests are copied over from the graphql-js reference implementation.

The Interface type will need work done going forward for Introspection to properly work, as it needs to have an `available_types` method added, which will also be used for Validation purposes. 
