### PR TITLE
Basic variable support

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -191,6 +191,11 @@ defmodule GraphQL.Execution.Executor do
     end
   end
 
+  defp value_from_ast(%{kind: :Argument, value: %{kind: :Variable, name: %{value: value}}}, type, variable_values) do
+    variable_value = Map.get(variable_values, String.to_atom(value))
+    GraphQL.Types.parse_value(type.type, variable_value)
+  end
+
   defp value_from_ast(value_ast, type, _variable_values) do
     GraphQL.Types.parse_value(type.type, value_ast.value.value)
   end

--- a/test/graphql/type/enum_test.exs
+++ b/test/graphql/type/enum_test.exs
@@ -93,10 +93,9 @@ defmodule GraphQL.Lang.Type.EnumTest do
     assert_execute {"{ color_enum(from_int: GREEN) }", TestSchema.schema}, "should return an argument error"
   end
 
-  @tag :skip # needs variable to be bound at some point
   test "accepts JSON string as enum variable" do
     query = "query test($color: Color!) { color_enum(from_enum: $color) }"
-    assert_execute {query, TestSchema.schema, %{color: "BLUE"}}, "failed"
+    assert_execute {query, TestSchema.schema, %{}, %{color: "BLUE"}}, %{color_enum: "BLUE"}
   end
 
   @tag :skip

--- a/test/star_wars/query_test.exs
+++ b/test/star_wars/query_test.exs
@@ -64,22 +64,20 @@ defmodule GraphQL.StarWars.QueryTest do
      assert_execute({query, StarWars.Schema.schema}, %{human: %{name: "Luke Skywalker"}})
   end
 
-  @tag :skip # needs variables to work
   test "Allows us to create a generic query, then use it to fetch Luke Skywalker using his ID" do
     query = ~S[query fetch_id($some_id: String!) { human(id: $some_id) { name }}]
-    assert_execute({query, StarWars.Schema.schema, %{some_id: "1000"}}, %{human: %{name: "Luke Skywalker"}})
+    assert_execute({query, StarWars.Schema.schema, %{}, %{some_id: "1000"}}, %{human: %{name: "Luke Skywalker"}})
   end
 
-  @tag :skip # needs variables to work
   test "Allows us to create a generic query, then use it to fetch Han Solo using his ID" do
     query = ~S[query fetch_some_id($some_id: String!) { human(id: $some_id) { name }}]
-    assert_execute({query, StarWars.Schema.schema, %{some_id: "1002"}}, %{human: %{name: "Han Solo"}})
+    assert_execute({query, StarWars.Schema.schema, %{}, %{some_id: "1002"}}, %{human: %{name: "Han Solo"}})
   end
 
-  @tag :skip # needs variables to work
+  @tag :skip # returns %{} instead of nil. Which is right?
   test "Allows us to create a generic query, then pass an invalid ID to get null back" do
     query = ~S[query human_query($id: String!) { human(id: $id) { name }}]
-    assert_execute({query, StarWars.Schema.schema, %{id: "invalid id"}}, %{human: nil})
+    assert_execute({query, StarWars.Schema.schema, %{}, %{id: "invalid id"}}, %{human: nil})
   end
 
   test "Allows us to query for Luke, changing his key with an alias" do

--- a/test/support/star_wars/data.exs
+++ b/test/support/star_wars/data.exs
@@ -3,10 +3,12 @@ defmodule StarWars.Data do
     get_human(id) || get_droid(id)
   end
 
+  def get_human(nil), do: nil
   def get_human(id) do
     Map.get(human_data, String.to_atom(id), nil)
   end
 
+  def get_droid(nil), do: nil
   def get_droid(id) do
     Map.get(droid_data, String.to_atom(id), nil)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,6 +20,11 @@ defmodule ExUnit.TestHelpers do
     assert Executor.execute(schema, doc, data) == {:ok, expected_output}
   end
 
+  def assert_execute({query, schema, data, variables}, expected_output) do
+    {:ok, doc} = Parser.parse(query)
+    assert Executor.execute(schema, doc, data, variables) == {:ok, expected_output}
+  end
+
   def assert_execute_error({query, schema}, expected_output) do
     {:ok, doc} = Parser.parse(query)
     assert Executor.execute(schema, doc) == {:error, expected_output}


### PR DESCRIPTION
Enable passing in variable bindings from tests, and apply them in the queries in the executor.
