### PR TITLE
Fixing mutations so that they work in introspection

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -190,9 +190,9 @@ defmodule GraphQL.Execution.Executor do
 
   defp field_definition(_schema, parent_type, field_name) do
     case field_name do
-      :__typename -> GraphQL.Type.Introspection.meta("typename")
-      :__schema -> GraphQL.Type.Introspection.meta("schema")
-      :__type -> GraphQL.Type.Introspection.meta("type")
+      :__typename -> GraphQL.Type.Introspection.meta(:typename)
+      :__schema -> GraphQL.Type.Introspection.meta(:schema)
+      :__type -> GraphQL.Type.Introspection.meta(:type)
       _ -> maybe_unwrap(parent_type.fields)[field_name]
     end
   end

--- a/lib/graphql/type/introspection.ex
+++ b/lib/graphql/type/introspection.ex
@@ -31,7 +31,7 @@ defmodule GraphQL.Type.Introspection do
         mutationType: %{
           description: "If this server supports mutation, the type that mutation operations will be rooted at.",
           type: GraphQL.Type.Introspection.type,
-          resolve: nil #fn(%{mutation: mutation}, _, _) -> mutation end
+          resolve: fn(%{mutation: mutation}, _, _) -> mutation end
         },
         subscriptionType: %{
           description: "If this server support subscription, the type that subscription operations will be rooted at.",
@@ -397,7 +397,7 @@ defmodule GraphQL.Type.Introspection do
     """
   end
 
-  def meta("type") do
+  def meta(:type) do
     %{
       name: "__type",
       type: GraphQL.Type.Introspection.type,
@@ -412,7 +412,7 @@ defmodule GraphQL.Type.Introspection do
     }
   end
 
-  def meta("typename") do
+  def meta(:typename) do
     %{
       name: "__typename",
       type: %NonNull{ofType: %String{}},
@@ -422,7 +422,7 @@ defmodule GraphQL.Type.Introspection do
     }
   end
 
-  def meta("schema") do
+  def meta(:schema) do
     %{
       name: "__schema",
       type: %NonNull{ofType: GraphQL.Type.Introspection.schema},

--- a/lib/graphql/type/schema.ex
+++ b/lib/graphql/type/schema.ex
@@ -4,6 +4,7 @@ defmodule GraphQL.Schema do
   def reduce_types(type) do
     %{}
     |> reduce_types(type.query)
+    |> reduce_types(type.mutation)
     |> reduce_types(GraphQL.Type.Introspection.schema)
   end
 
@@ -26,4 +27,5 @@ defmodule GraphQL.Schema do
     end
   end
   def reduce_types(typemap, %{name: name} = type), do: Map.put(typemap, name, type)
+  def reduce_types(typemap, nil), do: typemap
 end


### PR DESCRIPTION
Using :atom references instead of strings
