### PR TITLE
Added args to greeting example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ defmodule TestSchema do
         fields: %{
           greeting: %{
             type: %GraphQL.Type.String{},
-            resolve: &TestSchema.greeting/3
+            resolve: &TestSchema.greeting/3,
+            description: "Greeting",
+            args: %{
+              name: %{type: %GraphQL.Type.String{}, description: "The name of who you'd like to greet."},
+            }
           }
         }
       }


### PR DESCRIPTION
This makes it so the example in the `readme` is documented properly if you hook it up to `graphiql`. Plus it shows are `args` work and how to add a description to a `field`.
