### PR TITLE
Merge duplicate field definitions

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -97,7 +97,10 @@ defmodule GraphQL.Execution.Executor do
   defp collect_fields(context, runtime_type, selection_set, field_fragment_map \\ %{fields: %{}, fragments: %{}}) do
     Enum.reduce selection_set[:selections], field_fragment_map, fn(selection, field_fragment_map) ->
       case selection do
-        %{kind: :Field} -> put_in(field_fragment_map.fields[field_entry_key(selection)], [selection])
+        %{kind: :Field} ->
+          field_name = field_entry_key(selection)
+          fields = field_fragment_map.fields[field_name] || []
+          put_in(field_fragment_map.fields[field_name], [selection | fields])
         %{kind: :InlineFragment} ->
           collect_fragment(context, runtime_type, selection, field_fragment_map)
         %{kind: :FragmentSpread} ->

--- a/test/graphql/execution/executor_test.exs
+++ b/test/graphql/execution/executor_test.exs
@@ -254,4 +254,27 @@ defmodule GraphQL.Execution.Executor.ExecutorTest do
 
     assert_execute {"{numbers(nums: [1, 2])}", schema}, %{numbers: [1, 2]}
   end
+
+  test "multiple definitions of the same field should be merged" do
+    schema = %Schema{
+      query: %ObjectType{
+        name: "PersonQuery",
+        fields: %{
+          person: %{
+            type: %ObjectType{
+              name: "Person",
+              fields: %{
+                id:   %{name: "id",   type: %ID{}},
+                name: %{name: "name", type: %String{}}
+              }
+            },
+            resolve: fn(_, _, _) -> %{id: "1", name: "Dave"} end
+          }
+        }
+      }
+    }
+
+    assert_execute {~S[{ person { id name } person { id } }], schema}, %{person: %{id: "1", name: "Dave"}}
+  end
+
 end


### PR DESCRIPTION
Relay relies on duplicate field definitions in their queries which we
were not handling correctly.

This merges the superset of all field defs.

Fixes https://github.com/graphql-elixir/graphql-relay-elixir/issues/14

Paired with @seanabrahams (thanks dude!)
