### PR TITLE
Validations/unique operation names

### DIFF
--- a/lib/graphql/lang/ast/parallel_visitor.ex
+++ b/lib/graphql/lang/ast/parallel_visitor.ex
@@ -1,0 +1,67 @@
+
+defmodule GraphQL.Lang.AST.ParallelVisitor do
+  @moduledoc ~S"""
+  A ParallelVisitor runs all child visitors in parallel instead of serially like the CompositeVisitor.
+
+  In this context, 'in parallel' really means that for each node in the AST, each visitor will be invoked
+  for each node in the AST, but the :break/:continue return value of enter and leave is maintained per-visitor.
+
+  This means invividual visitors can bail out of AST processing as soon as possible and not waste cycles.
+
+  This code based on the graphql-js *visitInParallel* function.
+  """
+
+  alias GraphQL.Lang.AST.Visitor
+  alias GraphQL.Lang.AST.InitialisingVisitor
+  alias GraphQL.Lang.AST.PostprocessingVisitor
+
+  defstruct visitors: []
+  
+  defimpl Visitor do
+    def enter(visitor, node, accumulator) do
+      accumulator = Enum.reduce(visitor.visitors, accumulator, fn(child_visitor, acc) ->
+        if !skipping?(accumulator, child_visitor) do
+          acc = case child_visitor |> Visitor.enter(node, accumulator) do
+            {:continue, next_accumulator} -> next_accumulator
+            {:break, next_accumulator} ->
+              put_in(next_accumulator[:skipping][child_visitor], node)
+          end
+        end
+        acc
+      end)
+      {:continue, accumulator}
+    end
+
+    def leave(visitor, node, accumulator) do
+      accumulator = Enum.reduce(visitor.visitors, accumulator, fn(child_visitor, acc) ->
+        cond do
+          !skipping?(acc, child_visitor) ->
+            {_, next_accumulator} = child_visitor |> Visitor.leave(node, acc)
+            next_accumulator
+          accumulator[:skipping][child_visitor] == node ->
+            put_in(acc[:skipping][child_visitor], false)
+          true -> accumulator
+        end
+      end)
+      {:continue, accumulator}
+    end
+
+    defp skipping?(accumulator, child_visitor) do
+      Map.has_key?(accumulator[:skipping], child_visitor)
+    end
+  end
+
+  defimpl InitialisingVisitor do
+    def init(visitor, accumulator) do
+      accumulator = put_in(accumulator[:skipping], %{})
+      Enum.reduce(visitor.visitors, accumulator, &InitialisingVisitor.init/2)
+    end
+  end
+
+  defimpl PostprocessingVisitor do
+    def finish(visitor, accumulator) do
+      Enum.reduce(visitor.visitors, accumulator, &PostprocessingVisitor.finish/2)
+    end
+  end
+
+end

--- a/lib/graphql/lang/ast/type_info.ex
+++ b/lib/graphql/lang/ast/type_info.ex
@@ -58,7 +58,12 @@ defmodule GraphQL.Lang.AST.TypeInfo do
       name == Introspection.meta(:typename)[:name] ->
         Introspection.meta(:typename)
       parent_type.__struct__ == GraphQL.Type.ObjectType || parent_type.__struct__ == GraphQL.Type.Interface ->
-        parent_type.fields[name]
+        # FIXME: this "function or map" logic is repeated in the executor. DRY IT UP.
+        if is_function(parent_type.fields) do
+          parent_type.fields.()[name]
+        else
+          parent_type.fields[name]
+        end
       true ->
         nil
     end

--- a/lib/graphql/lang/ast/type_info_visitor.ex
+++ b/lib/graphql/lang/ast/type_info_visitor.ex
@@ -13,6 +13,7 @@ defmodule GraphQL.Lang.AST.TypeInfoVisitor do
   alias GraphQL.Util.Stack
   alias GraphQL.Lang.AST.TypeInfo
   alias GraphQL.Lang.AST.Visitor
+  alias GraphQL.Schema
 
   defstruct name: "TypeInfoVisitor"
 
@@ -93,13 +94,13 @@ defmodule GraphQL.Lang.AST.TypeInfoVisitor do
           stack_push(:type_stack, type)
         kind when kind in [:InlineFragment, :FragmentDefinition] ->
           output_type = if node.typeCondition do
-            Schema.type_from_ast(accumulator[:type_info].schema, node.typeCondition)
+            Schema.type_from_ast(node.typeCondition, accumulator[:type_info].schema)
           else
             TypeInfo.type(accumulator[:type_info])
           end
           stack_push(:type_stack, output_type)
         :VariableDefinition ->
-          input_type =  Schema.type_from_ast(accumulator[:type_info].schema, node.type)
+          input_type = Schema.type_from_ast(node.type, accumulator[:type_info].schema)
           stack_push(:input_type_stack, input_type)
         :Argument ->
           field_or_directive = TypeInfo.directive(accumulator[:type_info]) ||

--- a/lib/graphql/type/schema.ex
+++ b/lib/graphql/type/schema.ex
@@ -14,6 +14,7 @@ defmodule GraphQL.Schema do
 
   defstruct query: nil, mutation: nil, types: []
 
+  # FIXME: I think *schema* should be the first argument in this module.
   def type_from_ast(nil, _), do: nil
   def type_from_ast(%{kind: :NonNullType,} = input_type_ast, schema) do
     %GraphQL.Type.NonNull{ofType: type_from_ast(input_type_ast.type, schema)}

--- a/lib/graphql/validation/rules/unique_operation_names.ex
+++ b/lib/graphql/validation/rules/unique_operation_names.ex
@@ -1,0 +1,41 @@
+
+defmodule GraphQL.Validation.Rules.UniqueOperationNames do
+
+  alias GraphQL.Lang.AST.Visitor
+  alias GraphQL.Lang.AST.InitialisingVisitor
+
+  defstruct name: "UniqueOperationNames"
+
+  defimpl InitialisingVisitor do
+    def init(_visitor, accumulator) do
+      Map.merge(%{operation_names: %{}}, accumulator)
+    end
+  end
+
+  defimpl Visitor do
+    def enter(_visitor, node, accumulator) do
+      if node.kind == :OperationDefinition && Map.has_key?(node, :name) do
+        op_name = node.name
+        if op_name.value do
+          if accumulator[:operation_names][op_name.value] do
+            accumulator = put_in(
+              accumulator[:validation_errors],
+              [duplicate_operation_message(op_name)] ++ accumulator[:validation_errors]
+            )
+          else
+            accumulator = put_in(accumulator[:operation_names][op_name.value], true)
+          end
+        end
+      end
+      {:continue, accumulator}
+    end
+
+    def leave(_visitor, _node, accumulator) do
+      {:continue, accumulator}
+    end
+
+    defp duplicate_operation_message(op_name) do
+      "There can only be one operation named '#{op_name.value}'."
+    end
+  end
+end

--- a/test/graphql/validation/rules/unique_operation_names_test.exs
+++ b/test/graphql/validation/rules/unique_operation_names_test.exs
@@ -1,0 +1,108 @@
+
+Code.require_file "../../../support/validations.exs", __DIR__
+
+defmodule GraphQL.Validation.Rules.UniqueOperationNamesTest do
+  use ExUnit.Case, async: true
+
+  import ValidationsSupport
+
+  alias GraphQL.Validation.Rules.UniqueOperationNames
+
+  test "no operations" do
+    assert_passes_rule(""" 
+      fragment fragA on Type {
+        field
+      }
+    """, %UniqueOperationNames{})
+  end
+
+  test "one anon operation" do
+    assert_passes_rule("""
+      {
+        field
+      }
+    """, %UniqueOperationNames{})
+  end
+
+  test "one named operation" do
+    assert_passes_rule("""
+      query Foo {
+        field
+      }
+    """, %UniqueOperationNames{})
+  end
+
+  test "multiple operations" do
+    assert_passes_rule("""
+      query Foo {
+        field
+      }
+
+      query Bar {
+        field
+      }
+    """, %UniqueOperationNames{})
+  end
+
+  test "multiple operations of different types" do
+    assert_passes_rule("""
+      query Foo {
+        field
+      }
+
+      mutation Bar {
+        field
+      }
+
+      # TODO: add this when subscription support is added
+      #subscription Baz {
+      #  field
+      #}
+    """, %UniqueOperationNames{})
+  end
+
+  test "fragment and operation named the same" do
+    assert_passes_rule("""
+      query Foo {
+        ...Foo
+      }
+      fragment Foo on Type {
+        field
+      }
+    """, %UniqueOperationNames{})
+  end
+
+  test "multiple operations of same name" do
+    assert_fails_rule("""
+      query Foo {
+        fieldA
+      }
+      query Foo {
+        fieldB
+      }
+    """, %UniqueOperationNames{})
+  end
+
+  test "multiple ops of same name of different types (mutation)" do
+    assert_fails_rule("""
+      query Foo {
+        fieldA
+      }
+      mutation Foo {
+        fieldB
+      }
+    """, %UniqueOperationNames{})
+  end
+
+  @tag :skip
+  test "multiple ops of same name of different types (subscription)" do
+    assert_fails_rule("""
+      query Foo {
+        fieldA
+      }
+      subscription Foo {
+        fieldB
+      }
+    """, %UniqueOperationNames{})
+  end
+end

--- a/test/support/validations.exs
+++ b/test/support/validations.exs
@@ -1,0 +1,286 @@
+
+defmodule ValidationsSupport do
+  use ExUnit.Case, async: true
+
+  alias GraphQL.Schema
+  alias GraphQL.Type.ObjectType
+  alias GraphQL.Type.List
+  alias GraphQL.Type.ID
+  alias GraphQL.Type.String
+  alias GraphQL.Type.Int
+  alias GraphQL.Type.Boolean
+  alias GraphQL.Type.Interface
+  alias GraphQL.Type.Union
+  alias GraphQL.Type.Enum
+
+  alias GraphQL.Lang.Parser
+  alias GraphQL.Lang.AST.CompositeVisitor
+  alias GraphQL.Lang.AST.ParallelVisitor
+  alias GraphQL.Lang.AST.TypeInfoVisitor
+  alias GraphQL.Lang.AST.TypeInfo
+
+  alias GraphQL.Lang.AST.Reducer
+
+  defmodule Being do
+    def type do
+      %Interface{
+        name: "Being",
+        fields: %{
+          name: %String{},
+          args: %{ surname: %{ type: %Boolean{} } }
+        }
+      }
+    end
+  end
+
+  defmodule Pet do
+    def type do
+      %Interface{
+        name: "Pet",
+        fields: %{
+          name: %String{},
+          args: %{ surname: %{ type: %Boolean{} } }
+        }
+      }
+    end
+  end
+
+  defmodule Canine do
+    def type do
+      %Interface{
+        name: "Canine",
+        fields: %{
+          name: %String{},
+          args: %{ surname: %{ type: %Boolean{} } }
+        }
+      }
+    end
+  end
+
+  defmodule DogCommand do
+    def type do
+      %Enum{
+        name: "DogCommand",
+        values: %{
+          SIT: %{ value: 0 },
+          HEEL: %{ value: 1 },
+          DOWN: %{ value: 2 }
+        }
+      }
+    end
+  end
+
+  defmodule Dog do
+    def type do
+      %ObjectType{
+        name: "Dog",
+        fields: fn() -> %{
+          name: %{
+            type: %String{},
+            args: %{ surname: %{ type: %Boolean{} }}
+          },
+          nickname: %{ type: %String{} },
+          barks: %{ type: %Boolean{} },
+          barkVolume: %{ type: %Int{} },
+          doesKnowCommand: %{
+            type: %Boolean{},
+            args: %{
+              dogCommand: %{ type: DogCommand.type }
+            }
+          },
+          isHouseTrained: %{
+            type: %Boolean{},
+            args: %{
+              atOtherHomes: %{
+                type: %Boolean{},
+                defaultValue: true
+              }
+            }
+          },
+          isAtLocation: %{
+            type: %Boolean{},
+            args: %{
+              x: %{ type: %Int{} },
+              y: %{ type: %Int{} }
+            }
+          }
+        } end,
+        interfaces: [ Being.type, Pet.type, Canine.type ]
+      }
+    end
+  end
+
+  defmodule FurColor do
+    def type do
+      %Enum{
+        name: "FurColor",
+        values: %{
+          BROWN: %{ value: 0 },
+          BLACK: %{ value: 1 },
+          TAN: %{ value: 2 },
+          SPOTTED: %{ value: 3 }
+        }
+      }
+    end
+  end
+
+
+  defmodule Cat do
+    def type do
+      %ObjectType{
+        name: "Cat",
+        fields: fn() -> %{
+          name: %{
+            type: %String{},
+            args: %{ surname: %{ type: %Boolean{} }}
+          },
+          nickname: %{ type: %String{} },
+          meows: %{ type: %Boolean{} },
+          meowVolume: %{ type: %Int{} },
+          furColor: %{ type: FurColor.type }
+        } end,
+        interfaces: [ Being.type, Pet.type ]
+      }
+    end
+  end
+
+  defmodule Intelligent do
+    def type do
+      %Interface{
+        name: "Intelligent",
+        fields: %{
+          iq: %{ type: %Int{} }
+        }
+      }
+    end
+  end
+
+  defmodule CatOrDog do
+    def type do
+      %Union{
+        name: "CatOrDog",
+        types: [ Dog.type, Cat.type ]
+      }
+    end
+  end
+
+  defmodule Human do
+    def type do
+      %ObjectType{
+        name: "Human",
+        interfaces: [ Being.type, Intelligent.type ],
+        fields: fn() -> %{
+          name: %{
+            type: %String{},
+            args: %{ surname: %{ type: %Boolean{} }}
+          },
+          pets: %{ type: %List{ ofType: Pet.type } },
+          relatives: %{ type: %List{ ofType: Human.type } },
+          iq: %{ type: %Int{} },
+        } end
+      }
+    end
+  end
+
+  defmodule Alien do
+    def type do
+      %ObjectType{
+        name: "Alien",
+        interfaces: [ Being.type, Intelligent.type ],
+        fields: %{
+          name: %{
+            type: %String{},
+            args: %{ surname: %{ type: %Boolean{} } }
+          },
+          numEyes: %{ type: %Int{} },
+          iq: %{ type: %Int{} }
+        }
+      }
+    end
+  end
+
+  defmodule HumanOrAlien do
+    def type do
+      %Union{
+        name: "HumanOrAlien",
+        types: [ Human.type, Alien.type ]
+      }
+    end
+  end
+
+  defmodule DogOrHuman do
+    def type do
+      %Union{
+        name: "DogOrHuman",
+        types: [ Human.type, Dog.type ]
+      }
+    end
+  end
+
+
+       
+  defmodule TestSchema do
+    def schema do
+      %Schema{
+        query: %ObjectType{
+          name: "QueryRoot",
+          fields: fn() -> %{
+            human: %{
+              args: %{ id: %{ type: %ID{} } },
+              type: Human.type
+            },
+            alien: %{ type: Alien.type },
+            dog: %{ type: Dog.type },
+            cat: %{ type: Cat.type },
+            pet: %{ type: Pet.type },
+            catOrDog: %{ type: CatOrDog.type },
+            dogOrHuman: %{ type: DogOrHuman.type },
+            humanOrAlien: %{ type: HumanOrAlien.type },
+            #complicatedArgs: %{ type: ComplicatedArgs.type },
+          } end
+        }
+      }
+    end
+  end
+
+
+  defp validate(schema, query_string, rules) do
+    {:ok, ast} = Parser.parse(query_string)
+    validation_pipeline = CompositeVisitor.compose([
+      %TypeInfoVisitor{},
+      %ParallelVisitor{visitors: rules}
+    ])
+    result = Reducer.reduce(ast, validation_pipeline, %{
+      type_info: %TypeInfo{schema: schema},
+      validation_errors: []
+    })
+    result[:validation_errors]
+  end
+
+  def assert_valid(schema, query_string, rules) do
+    errors = validate(schema, query_string, rules)
+    assert errors == [] 
+  end
+
+  def assert_invalid(schema, query_string, rules, expected_errors) do
+    errors = validate(schema, query_string, rules)
+    assert errors == expected_errors
+  end
+
+  def assert_invalid(schema, query_string, rules) do
+    errors = validate(schema, query_string, rules)
+    assert length(errors) > 0
+  end
+
+  def assert_passes_rule(query_string, rule) do
+    assert_valid(TestSchema.schema, query_string, [ rule ])
+  end
+
+  def assert_fails_rule(query_string, rule, errors) do
+    assert_invalid(TestSchema.schema, query_string, [ rule ], errors)
+  end
+
+  def assert_fails_rule(query_string, rule) do
+    assert_invalid(TestSchema.schema, query_string, [ rule ])
+  end
+end


### PR DESCRIPTION
I've created a validator that works with the AST visitor/reducer infrastructure.

This visitor is so simple that it does not need anything from the TypeInfoVisitor to do its job.

I'm seeking feedback for anything and everything (overall approach, stylistic stuff etc). Don't hold back!

ParallelVisitor still needs tests (it's tested indirectly right now).

Next I'd like to port `FieldsOnCorrectType` because that will exercise the `TypeInfoVisitor`. 
