### PR TITLE
Addressing various issues with Enum variables.

### DIFF
--- a/lib/graphql/execution/executor.ex
+++ b/lib/graphql/execution/executor.ex
@@ -296,8 +296,10 @@ defmodule GraphQL.Execution.Executor do
   end
 
   def value_from_ast(%{value: %{kind: :Variable, name: %{value: value}}}, type, variable_values) do
-    variable_value = Map.get(variable_values, value)
-    GraphQL.Types.parse_value(type, variable_value)
+    case Map.get(variable_values, value) do
+      nil -> nil
+      variable_value -> GraphQL.Types.parse_value(type, variable_value)
+    end
   end
 
   # if it isn't a variable or object input type, that means it's invalid

--- a/lib/graphql/type/enum.ex
+++ b/lib/graphql/type/enum.ex
@@ -31,12 +31,20 @@ defmodule GraphQL.Type.Enum do
 end
 
 defimpl GraphQL.Types, for: GraphQL.Type.Enum do
+  def parse_value(struct, value) when is_integer(value) do
+    value
+  end
   def parse_value(struct, value) do
     GraphQL.Type.Enum.values(struct) |> Map.get(String.to_atom(value))
   end
 
   def parse_literal(struct, value) do
-    GraphQL.Type.Enum.values(struct) |> Map.get(String.to_atom(value.value))
+    values = GraphQL.Type.Enum.values(struct)
+    key = String.to_atom(value.value)
+    case Map.has_key?(values, key) do
+      true -> Map.get(values, key)
+      false -> nil
+    end
   end
 
   def serialize(struct, wanted) do


### PR DESCRIPTION
- Allowing default values to get assigned correctly when a query defines
  an enum variable with a default.
- Query can take an optional Enum argument and correctly fall back if
  that value is not specified.
- Lots of unit tests using mutations to ensure that Enum's work as
  expected.
