### PR TITLE
Refactor: simplify TestHelper

### DIFF
--- a/lib/graphql/type/boolean.ex
+++ b/lib/graphql/type/boolean.ex
@@ -1,8 +1,5 @@
 defmodule GraphQL.Type.Boolean do
-  defstruct name: "Boolean", description:
-    """
-    The `Boolean` scalar type represents `true` or `false`.
-    """
+  defstruct name: "Boolean", description: "The `Boolean` scalar type represents `true` or `false`."
 
   def coerce(""), do: false
   def coerce(0), do: false

--- a/lib/graphql/type/float.ex
+++ b/lib/graphql/type/float.ex
@@ -4,7 +4,7 @@ defmodule GraphQL.Type.Float do
     """
     The `Float` scalar type represents signed double-precision fractional
     values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
-    """
+    """ |> GraphQL.Util.Text.normalize
 
   def coerce(false), do: 0
   def coerce(true), do: 1

--- a/lib/graphql/type/id.ex
+++ b/lib/graphql/type/id.ex
@@ -6,7 +6,7 @@ defmodule GraphQL.Type.ID do
     response as a String; however, it is not intended to be human-readable.
     When expected as an input type, any string (such as `"4"`) or integer
     (such as `4`) input value will be accepted as an ID.
-    """
+    """ |> GraphQL.Util.Text.normalize
 
   def coerce(value), do: to_string(value)
 

--- a/lib/graphql/type/int.ex
+++ b/lib/graphql/type/int.ex
@@ -9,7 +9,7 @@ defmodule GraphQL.Type.Int do
     values. Int can represent values between -(2^53 - 1) and 2^53 - 1 since
     represented in JSON as double-precision floating point numbers specified
     by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
-    """
+    """ |> GraphQL.Util.Text.normalize
 
   def coerce(false), do: 0
   def coerce(true), do: 1

--- a/lib/graphql/type/introspection.ex
+++ b/lib/graphql/type/introspection.ex
@@ -19,6 +19,8 @@ defmodule GraphQL.Type.Introspection do
   alias GraphQL.Type.Introspection.InputValue
   alias GraphQL.Type.Introspection.EnumValue
 
+  alias GraphQL.Util.Text
+
   defmodule Schema do
     def type do
       %ObjectType{
@@ -28,7 +30,7 @@ defmodule GraphQL.Type.Introspection do
           A GraphQL Schema defines the capabilities of a GraphQL server. It
           exposes all available types and directives on the server, as well as
           the entry points for query, mutation, and subscription operations.
-          """,
+          """ |> Text.normalize,
         fields: %{
           types: %{
             description: "A list of all types supported by this server.",
@@ -75,7 +77,7 @@ defmodule GraphQL.Type.Introspection do
           execution behavior in ways field arguments will not suffice, such as
           conditionally including or skipping a field. Directives provide this by
           describing additional information to the executor
-          """,
+          """ |> Text.normalize,
         fields: %{
           name: %{type: %NonNull{ofType: %String{}}},
           description: %{type: %String{}},
@@ -106,7 +108,7 @@ defmodule GraphQL.Type.Introspection do
           Object and Interface types provide the fields they describe. Abstract
           types, Union and Interface, provide the Object types possible
           at runtime. List and NonNull types compose other types.
-          """,
+          """ |> Text.normalize,
         fields: %{
           kind: %{
             type: %NonNull{ofType: TypeKind},
@@ -242,7 +244,7 @@ defmodule GraphQL.Type.Introspection do
           """
           Object and Interface types are described by a list of Fields, each of
           which has a name, potentially a list of arguments, and a return type.
-          """,
+          """ |> Text.normalize,
         fields: %{
           name: %{type: %NonNull{ofType: %String{}}},
           description: %{type: %String{}},
@@ -274,7 +276,7 @@ defmodule GraphQL.Type.Introspection do
           Arguments provided to Fields or Directives and the input fields of an
           InputObject are represented as Input Values which describe their type
           and optionally a default value.
-          """,
+          """ |> Text.normalize,
         fields: %{
           name: %{type: %NonNull{ofType: %String{}}},
           description: %{type: %String{}},
@@ -300,7 +302,7 @@ defmodule GraphQL.Type.Introspection do
           One possible value for a given Enum. Enum values are unique values, not
           a placeholder for a string or numeric value. However an Enum value is
           returned in a JSON response as a string.
-          """,
+          """ |> Text.normalize,
         fields: %{
           name: %{type: %NonNull{ofType: %String{}}},
           description: %{type: %String{}},

--- a/lib/graphql/type/json.ex
+++ b/lib/graphql/type/json.ex
@@ -2,7 +2,7 @@ defmodule GraphQL.Type.JSON do
   defstruct name: "JSON", description:
     """
     The `JSON` type represents dynamic objects in JSON.
-    """
+    """ |> GraphQL.Util.Text.normalize
 
   def coerce(value), do: value
 end

--- a/lib/graphql/type/string.ex
+++ b/lib/graphql/type/string.ex
@@ -4,7 +4,7 @@ defmodule GraphQL.Type.String do
     The `String` scalar type represents textual data, represented as UTF-8
     character sequences. The String type is most often used by GraphQL to
     represent free-form human-readable text.
-    """
+    """ |> GraphQL.Util.Text.normalize
 
   def coerce(nil), do: nil
   def coerce(value) when is_map(value) do

--- a/lib/graphql/util/text.ex
+++ b/lib/graphql/util/text.ex
@@ -1,0 +1,6 @@
+defmodule GraphQL.Util.Text do
+  def normalize(text) do
+    text |> String.replace(~r/\n/, " ", global: true) |> String.strip()
+  end
+end
+

--- a/test/graphql/execution/executor_blog_schema_test.exs
+++ b/test/graphql/execution/executor_blog_schema_test.exs
@@ -129,34 +129,35 @@ defmodule GraphQL.Execution.Executor.ExecutorBlogSchemaTest do
     }
     """
 
-    assert_execute {query, blog_schema},
-      %{
-        feed: [
-          %{id: "1",  title: "My Article 1"},
-          %{id: "2",  title: "My Article 2"}
-        ],
-        article: %{
-          id: "1",
-          isPublished: true,
-          title: "My Article 1",
-          body: "This is a post",
-          author: %{
-            id: "123",
-            name: "John Smith",
-            pic: %{
-              url: "cdn://123",
-              width: 640,
-              height: 480
-            },
-            recentArticle: %{
-              id: "1000",
-              isPublished: true,
-              title: "GraphQL and Elixir: A powerful pair",
-              body: "Elixir is fast, GraphQL is awesome!",
-              keywords: ["elixir", "graphql"]
-            }
+    {:ok, result} = execute(blog_schema, query)
+
+    assert_data(result, %{
+      feed: [
+        %{id: "1",  title: "My Article 1"},
+        %{id: "2",  title: "My Article 2"}
+      ],
+      article: %{
+        id: "1",
+        isPublished: true,
+        title: "My Article 1",
+        body: "This is a post",
+        author: %{
+          id: "123",
+          name: "John Smith",
+          pic: %{
+            url: "cdn://123",
+            width: 640,
+            height: 480
+          },
+          recentArticle: %{
+            id: "1000",
+            isPublished: true,
+            title: "GraphQL and Elixir: A powerful pair",
+            body: "Elixir is fast, GraphQL is awesome!",
+            keywords: ["elixir", "graphql"]
           }
         }
       }
+    })
   end
 end

--- a/test/graphql/execution/mutations_test.exs
+++ b/test/graphql/execution/mutations_test.exs
@@ -67,11 +67,13 @@ defmodule GraphQL.Execution.Executor.MutationsTest do
       }
     """
 
-    assert_execute {doc, TestSchema.schema}, %{
+    {:ok, result} = execute(TestSchema.schema, doc)
+
+    assert_data(result, %{
       first: %{theNumber: 1},
       second: %{theNumber: 2},
       third: %{theNumber: 3},
-    }
+    })
   end
 
   test "evaluates mutations correctly in the presense of a failed mutation" do
@@ -89,7 +91,9 @@ defmodule GraphQL.Execution.Executor.MutationsTest do
       }
     """
 
-    assert_execute {doc, TestSchema.schema}, %{
+    {:ok, result} = execute(TestSchema.schema, doc)
+
+    assert_data(result, %{
       first: %{
         theNumber: 1
       },
@@ -97,11 +101,9 @@ defmodule GraphQL.Execution.Executor.MutationsTest do
       third: %{
         theNumber: 3
       }
-    }
+    })
 
-    assert_execute_error {doc, TestSchema.schema}, [
-      %{"message" => "Cannot change the number"}
-    ]
+    assert_has_error(result, %{"message" => "Cannot change the number"})
   end
 end
 

--- a/test/graphql/type/enum_test.exs
+++ b/test/graphql/type/enum_test.exs
@@ -62,39 +62,47 @@ defmodule GraphQL.Lang.Type.EnumTest do
   end
 
   test "accepts enum literals as input" do
-    assert_execute {"{ color_int(from_enum: GREEN) }", TestSchema.schema}, %{color_int: 1}
+    {:ok, result} = execute(TestSchema.schema, "{ color_int(from_enum: GREEN) }")
+    assert_data(result, %{color_int: 1})
   end
 
   test "enum may be output type" do
-    assert_execute {"{ color_enum(from_int: 1) }", TestSchema.schema}, %{color_enum: "GREEN"}
+    {:ok, result} = execute(TestSchema.schema, "{ color_enum(from_int: 1) }")
+    assert_data(result, %{color_enum: "GREEN"})
   end
 
   test "enum may be both input and output type" do
-    assert_execute {"{ color_enum(from_enum: GREEN) }", TestSchema.schema}, %{color_enum: "GREEN"}
+    {:ok, result} = execute(TestSchema.schema, "{ color_enum(from_enum: GREEN) }")
+    assert_data(result, %{color_enum: "GREEN"})
   end
 
   @tag :skip # needs type validation
   test "does not accept string literals" do
-    assert_execute {~S[{ color_enum(from_enum: "GREEN") }], TestSchema.schema}, "should return an argument error"
+    {:ok, result} = execute(TestSchema.schema, ~S[{ color_enum(from_enum: "GREEN") }])
+    assert_has_error(result, %{message: "replace with actual message"})
   end
 
   test "does not accept incorrect internal value" do
-    assert_execute {~S[{ color_enum(from_string: "GREEN") }], TestSchema.schema}, %{color_enum: nil}
+    {:ok, result} = execute(TestSchema.schema, ~S[{ color_enum(from_string: "GREEN") }])
+    assert_data(result, %{color_enum: nil})
   end
 
   @tag :skip # needs type validation
   test "does not accept internal value in place of enum literal" do
-    assert_execute {"{ color_enum(from_enum: 1) }", TestSchema.schema}, "should return an argument error"
+    {:ok, result} = execute(TestSchema.schema, ~S[{ color_enum(from_enum: 1) }])
+    assert_has_error(result, %{message: "replace with actual message"})
   end
 
   @tag :skip # needs type validation
   test "does not accept enum literal in place of int" do
-    assert_execute {"{ color_enum(from_int: GREEN) }", TestSchema.schema}, "should return an argument error"
+    {:ok, result} = execute(TestSchema.schema, ~S[{ color_enum(from_int: GREEN) }])
+    assert_has_error(result, %{message: "replace with actual message"})
   end
 
   test "accepts JSON string as enum variable" do
     query = "query test($color: Color!) { color_enum(from_enum: $color) }"
-    assert_execute {query, TestSchema.schema, %{}, %{"color" => "BLUE"}}, %{"color_enum" => "BLUE"}
+    {:ok, result} = execute(TestSchema.schema, query, variable_values: %{"color" => "BLUE"})
+    assert_data(result, %{"color_enum" => "BLUE"})
   end
 
   @tag :skip
@@ -109,10 +117,12 @@ defmodule GraphQL.Lang.Type.EnumTest do
   test "does not accept internal value variable as enum input", do: :skipped
 
   test "enum value may have an internal value of 0" do
-    assert_execute {"{ color_enum(from_enum: RED), color_int(from_enum: RED) }", TestSchema.schema}, %{color_enum: "RED", color_int: 0}
+    {:ok, result} = execute(TestSchema.schema, "{ color_enum(from_enum: RED), color_int(from_enum: RED) }")
+    assert_data(result, %{color_enum: "RED", color_int: 0})
   end
 
   test "enum inputs may be nullable" do
-    assert_execute {"{color_enum, color_int}", TestSchema.schema}, %{color_enum: nil, color_int: nil}
+    {:ok, result} = execute(TestSchema.schema, "{color_enum, color_int}")
+    assert_data(result, %{color_enum: nil, color_int: nil})
   end
 end

--- a/test/graphql/type/introspection_test.exs
+++ b/test/graphql/type/introspection_test.exs
@@ -20,12 +20,6 @@ defmodule GraphQL.Type.IntrospectionTest do
     end
   end
 
-  test "basic query introspection" do
-    # assert_execute
-    #   {GraphQL.Type.Introspection.query, EmptySchema.schema},
-  end
-
-  @tag :skip # order matters for this... ... hm.
   test "exposes descriptions on types and fields" do
     schema = %Schema{
       query: %ObjectType{
@@ -47,7 +41,8 @@ defmodule GraphQL.Type.IntrospectionTest do
     }
     """
 
-    assert_execute {query, schema}, %{
+    {:ok, result} = execute(schema, query)
+    assert_data(result, %{
       schemaType: %{
         name: "__Schema",
         description:
@@ -57,30 +52,30 @@ defmodule GraphQL.Type.IntrospectionTest do
           directives on the server, as well as the entry
           points for query, mutation,
           and subscription operations.
-          """,
+          """ |> GraphQL.Util.Text.normalize,
         fields: [
           %{
-            name: "types",
-            description: "A list of all types supported by this server."
-          },
-          %{
-            name: "queryType",
-            description: "The type that query operations will be rooted at."
+            name: "directives",
+            description: "A list of all directives supported by this server."
           },
           %{
             name: "mutationType",
             description: "If this server supports mutation, the type that mutation operations will be rooted at."
           },
           %{
+            name: "queryType",
+            description: "The type that query operations will be rooted at."
+          },
+          %{
             name: "subscriptionType",
             description: "If this server support subscription, the type that subscription operations will be rooted at.",
           },
           %{
-            name: "directives",
-            description: "A list of all directives supported by this server."
+            name: "types",
+            description: "A list of all types supported by this server."
           }
         ]
       }
-    }
+    })
   end
 end

--- a/test/graphql/type/union_interface_test.exs
+++ b/test/graphql/type/union_interface_test.exs
@@ -108,7 +108,8 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
         }
       }
     """
-    assert_execute {query, schema},
+    {:ok, result} = execute(schema, query)
+    assert_data(result,
       %{"Named" => %{"enumValues" => nil,
                   "fields" => [%{"name" => "name"}],
                   "inputFields" => nil, "interfaces" => nil,
@@ -120,6 +121,7 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
                   "kind" => "UNION", "name" => "Pet",
                   "possibleTypes" => [%{"name" => "Dog"},
                    %{"name" => "Cat"}]}}
+    )
   end
 
   test "executes using union types" do
@@ -136,7 +138,9 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
         }
       }
     """
-    assert_execute_without_validation {query, schema, john},
+
+    {:ok, result} = execute(schema, query, root_value: john, validate: false)
+    assert_data(result,
       %{"__typename" => "Person",
         "name" => "John",
         "pets" => [
@@ -144,6 +148,7 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
           %{"__typename" => "Cat", "meows" => false, "name" => "Garfield"}
         ]
       }
+    )
   end
 
   test "executes union types with inline fragments" do
@@ -164,7 +169,9 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
         }
       }
     """
-    assert_execute {query, schema, john},
+
+    {:ok, result} = execute(schema, query, root_value: john, validate: false)
+    assert_data(result,
       %{"__typename" => "Person",
         "name" => "John",
         "pets" => [
@@ -172,6 +179,7 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
           %{"__typename" => "Cat", "meows" => false, "name" => "Garfield"}
         ]
       }
+    )
   end
 
   test "executes using interface types" do
@@ -189,7 +197,8 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
       }
     """
 
-    assert_execute_without_validation {query, schema, john},
+    {:ok, result} = execute(schema, query, root_value: john, validate: false)
+    assert_data(result,
       %{"__typename" => "Person",
         "friends" => [
           %{"__typename" => "Person", "name" => "Liz"},
@@ -197,6 +206,7 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
         ],
         "name" => "John"
       }
+    )
   end
 
   test "executes types with inline fragments" do
@@ -217,7 +227,9 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
         }
       }
     """
-    assert_execute {query, schema, john},
+
+    {:ok, result} = execute(schema, query, root_value: john, validate: false)
+    assert_data(result,
       %{"__typename" => "Person",
         "friends" => [
           %{"__typename" => "Person", "name" => "Liz"},
@@ -225,6 +237,7 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
         ],
         "name" => "John"
       }
+    )
   end
 
   test "allows fragment conditions to be abstract types" do
@@ -259,18 +272,21 @@ defmodule GraphQL.Lang.Type.UnionInterfaceTest do
         }
       }
       """
-      assert_execute {query, schema, john},
-        %{"__typename" => "Person",
-          "name" => "John",
-          "friends" => [
-            %{"__typename" => "Person", "name" => "Liz"},
-            %{"__typename" => "Dog", "barks" => true, "name" => "Odie"}
-          ],
-          "pets" => [
-            %{"__typename" => "Dog", "barks" => true, "name" => "Odie"},
-            %{"__typename" => "Cat", "meows" => false, "name" => "Garfield"}
-          ]
-        }
+
+    {:ok, result} = execute(schema, query, root_value: john, validate: false)
+    assert_data(result,
+      %{"__typename" => "Person",
+        "name" => "John",
+        "friends" => [
+          %{"__typename" => "Person", "name" => "Liz"},
+          %{"__typename" => "Dog", "barks" => true, "name" => "Odie"}
+        ],
+        "pets" => [
+          %{"__typename" => "Dog", "barks" => true, "name" => "Odie"},
+          %{"__typename" => "Cat", "meows" => false, "name" => "Garfield"}
+        ]
+      }
+    )
   end
 
   test "gets execution info in resolver" do

--- a/test/graphql_test.exs
+++ b/test/graphql_test.exs
@@ -18,13 +18,15 @@ defmodule GraphQLTest do
   end
 
   test "Execute simple query" do
-    assert_execute {"{ a }", schema, %{a: "A"}}, %{a: "A"}
+    {:ok, result} = execute(schema, "{ a }", root_value: %{a: "A"})
+    assert_data(result, %{a: "A"})
   end
 
   test "Report parse error with message" do
-    assert_execute_error {"{", schema},
-      [%{message: "GraphQL: syntax error before:  on line 1", line_number: 1}]
-    assert_execute_error {"a", schema},
-      [%{message: "GraphQL: syntax error before: \"a\" on line 1", line_number: 1}]
+    {_, result} = execute(schema, "{")
+    assert_has_error(result, %{message: "GraphQL: syntax error before:  on line 1", line_number: 1})
+
+    {_, result} = execute(schema, "a")
+    assert_has_error(result, %{message: "GraphQL: syntax error before: \"a\" on line 1", line_number: 1})
   end
 end

--- a/test/star_wars/introspection_query_test.exs
+++ b/test/star_wars/introspection_query_test.exs
@@ -15,11 +15,13 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __schema: %{
         types: Enum.map(~w(Boolean Character Droid Episode Human Query String __Directive __EnumValue __Field __InputValue __Schema __Type __TypeKind), fn(t) -> %{name: t} end)
       }
-    }
+    })
   end
 
   test "Allows querying the schema for query type" do
@@ -32,9 +34,11 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __schema: %{queryType: %{name: "Query"}}
-    }
+    })
   end
 
   test "Allows querying the schema for a specific type" do
@@ -45,9 +49,11 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __type: %{name: "Droid"}
-    }
+    })
   end
 
   test "Allows querying the schema for an object kind" do
@@ -59,9 +65,11 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __type: %{name: "Droid", kind: "OBJECT"}
-    }
+    })
   end
 
   test "Allows querying the schema for an interface kind" do
@@ -73,9 +81,11 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __type: %{name: "Character", kind: "INTERFACE"}
-    }
+    })
   end
 
   test "Allows querying the schema for object fields" do
@@ -93,7 +103,9 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __type: %{
         fields: [
           %{name: "appears_in", type: %{kind: "LIST", name: nil}},
@@ -104,7 +116,7 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         ],
         name: "Droid"
       }
-    }
+    })
   end
 
   test "Allows querying the schema for nested object fields" do
@@ -126,7 +138,9 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __type: %{
         name: "Droid",
         fields: [
@@ -152,7 +166,7 @@ defmodule GraphQL.StarWars.IntrospectionTest do
           }
         ]
       }
-    }
+    })
   end
 
   @tag :skip # we need to add default_value before this will be complete
@@ -181,7 +195,9 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{}
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{})
   end
 
   test "Allows querying the schema for documentation" do
@@ -193,15 +209,18 @@ defmodule GraphQL.StarWars.IntrospectionTest do
         }
       }
     """
-    assert_execute {query, StarWars.Schema.schema}, %{
+
+    {:ok, result} = execute(StarWars.Schema.schema, query)
+    assert_data(result, %{
       __type: %{description: "A mechanical creature in the Star Wars universe", name: "Droid"}
-    }
+    })
   end
 
   test "Can run the full introspection query" do
-    assert_execute {GraphQL.Type.Introspection.query, StarWars.Schema.schema}, %{
+    {:ok, result} = execute(StarWars.Schema.schema, GraphQL.Type.Introspection.query)
+    assert_data(result, %{
       "__schema" => %{"directives" => nil, "mutationType" => nil, "queryType" => %{"name" => "Query"}, "subscriptionType" => nil,
-      "types" => [%{"description" => "The `Boolean` scalar type represents `true` or `false`.\n", "enumValues" => nil, "fields" => nil, "inputFields" => nil, "interfaces" => nil, "kind" => "SCALAR", "name" => "Boolean", "possibleTypes" => nil},
+      "types" => [%{"description" => "The `Boolean` scalar type represents `true` or `false`.", "enumValues" => nil, "fields" => nil, "inputFields" => nil, "interfaces" => nil, "kind" => "SCALAR", "name" => "Boolean", "possibleTypes" => nil},
        %{"description" => "A character in the Star Wars Trilogy", "enumValues" => nil,
          "fields" => [%{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "appears_in", "type" => %{"kind" => "LIST", "name" => nil, "ofType" => %{"kind" => "ENUM", "name" => "Episode", "ofType" => nil}}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "friends", "type" => %{"kind" => "LIST", "name" => nil, "ofType" => %{"kind" => "INTERFACE", "name" => "Character", "ofType" => nil}}},
@@ -232,9 +251,9 @@ defmodule GraphQL.StarWars.IntrospectionTest do
             "description" => nil, "isDeprecated" => nil, "name" => "hero", "type" => %{"kind" => "INTERFACE", "name" => "Character", "ofType" => nil}},
           %{"args" => [%{"defaultValue" => nil, "description" => "id of the human", "name" => "id", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}}}], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil,
             "name" => "human", "type" => %{"kind" => "OBJECT", "name" => "Human", "ofType" => nil}}], "inputFields" => nil, "interfaces" => [], "kind" => "OBJECT", "name" => "Query", "possibleTypes" => nil},
-       %{"description" => "The `String` scalar type represents textual data, represented as UTF-8\ncharacter sequences. The String type is most often used by GraphQL to\nrepresent free-form human-readable text.\n", "enumValues" => nil, "fields" => nil, "inputFields" => nil, "interfaces" => nil,
+       %{"description" => "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.", "enumValues" => nil, "fields" => nil, "inputFields" => nil, "interfaces" => nil,
          "kind" => "SCALAR", "name" => "String", "possibleTypes" => nil},
-       %{"description" => "A Directive provides a way to describe alternate runtime execution and\ntype validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL’s\nexecution behavior in ways field arguments will not suffice, such as\nconditionally including or skipping a field. Directives provide this by\ndescribing additional information to the executor\n",
+       %{"description" => "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.  In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor",
          "enumValues" => nil,
          "fields" => [%{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "args",
             "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "LIST", "name" => nil, "ofType" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "OBJECT", "name" => "__InputValue"}}}}},
@@ -244,13 +263,13 @@ defmodule GraphQL.StarWars.IntrospectionTest do
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "onFragment", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "SCALAR", "name" => "Boolean", "ofType" => nil}}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "onOperation", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "SCALAR", "name" => "Boolean", "ofType" => nil}}}], "inputFields" => nil, "interfaces" => [],
          "kind" => "OBJECT", "name" => "__Directive", "possibleTypes" => nil},
-       %{"description" => "One possible value for a given Enum. Enum values are unique values, not\na placeholder for a string or numeric value. However an Enum value is\nreturned in a JSON response as a string.\n", "enumValues" => nil,
+       %{"description" => "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.", "enumValues" => nil,
          "fields" => [%{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "deprecationReason", "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "description", "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "isDeprecated", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "SCALAR", "name" => "Boolean", "ofType" => nil}}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "name", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}}}], "inputFields" => nil, "interfaces" => [], "kind" => "OBJECT",
          "name" => "__EnumValue", "possibleTypes" => nil},
-       %{"description" => "Object and Interface types are described by a list of Fields, each of\nwhich has a name, potentially a list of arguments, and a return type.\n", "enumValues" => nil,
+       %{"description" => "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.", "enumValues" => nil,
          "fields" => [%{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "args",
             "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "LIST", "name" => nil, "ofType" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "OBJECT", "name" => "__InputValue"}}}}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "deprecationReason", "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}},
@@ -259,13 +278,13 @@ defmodule GraphQL.StarWars.IntrospectionTest do
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "name", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "type", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "OBJECT", "name" => "__Type", "ofType" => nil}}}], "inputFields" => nil, "interfaces" => [], "kind" => "OBJECT",
          "name" => "__Field", "possibleTypes" => nil},
-       %{"description" => "Arguments provided to Fields or Directives and the input fields of an\nInputObject are represented as Input Values which describe their type\nand optionally a default value.\n", "enumValues" => nil,
+       %{"description" => "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.", "enumValues" => nil,
          "fields" => [%{"args" => [], "deprecationReason" => nil, "description" => "A GraphQL-formatted string representing the default value for this input value.", "isDeprecated" => nil, "name" => "defaultValue", "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "description", "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "name", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}}},
           %{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "type", "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "OBJECT", "name" => "__Type", "ofType" => nil}}}], "inputFields" => nil, "interfaces" => [], "kind" => "OBJECT",
          "name" => "__InputValue", "possibleTypes" => nil},
-       %{"description" => "A GraphQL Schema defines the capabilities of a GraphQL server. It\nexposes all available types and directives on the server, as well as\nthe entry points for query, mutation, and subscription operations.\n", "enumValues" => nil,
+       %{"description" => "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.", "enumValues" => nil,
          "fields" => [%{"args" => [], "deprecationReason" => nil, "description" => "A list of all directives supported by this server.", "isDeprecated" => nil, "name" => "directives",
             "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "LIST", "name" => nil, "ofType" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "OBJECT", "name" => "__Directive"}}}}},
           %{"args" => [], "deprecationReason" => nil, "description" => "If this server supports mutation, the type that mutation operations will be rooted at.", "isDeprecated" => nil, "name" => "mutationType", "type" => %{"kind" => "OBJECT", "name" => "__Type", "ofType" => nil}},
@@ -274,7 +293,7 @@ defmodule GraphQL.StarWars.IntrospectionTest do
           %{"args" => [], "deprecationReason" => nil, "description" => "A list of all types supported by this server.", "isDeprecated" => nil, "name" => "types",
             "type" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "LIST", "name" => nil, "ofType" => %{"kind" => "NON_NULL", "name" => nil, "ofType" => %{"kind" => "OBJECT", "name" => "__Type"}}}}}], "inputFields" => nil, "interfaces" => [], "kind" => "OBJECT", "name" => "__Schema",
          "possibleTypes" => nil},
-       %{"description" => "The fundamental unit of any GraphQL Schema is the type. There are\nmany kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe\ninformation about that type. Scalar types provide no information\nbeyond a name and description, while Enum types provide their values.\nObject and Interface types provide the fields they describe. Abstract\ntypes, Union and Interface, provide the Object types possible\nat runtime. List and NonNull types compose other types.\n",
+       %{"description" => "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.  Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
          "enumValues" => nil,
          "fields" => [%{"args" => [], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "description", "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil}},
           %{"args" => [%{"defaultValue" => "false", "description" => nil, "name" => "includeDeprecated", "type" => %{"kind" => "SCALAR", "name" => "Boolean", "ofType" => nil}}], "deprecationReason" => nil, "description" => nil, "isDeprecated" => nil, "name" => "enumValues",
@@ -297,6 +316,6 @@ defmodule GraphQL.StarWars.IntrospectionTest do
           %{"deprecationReason" => nil, "description" => "Indicates this type is an object. `fields` and `interfaces` are valid fields.", "isDeprecated" => nil, "name" => "OBJECT"},
           %{"deprecationReason" => nil, "description" => "Indicates this type is a scalar.", "isDeprecated" => nil, "name" => "SCALAR"}, %{"deprecationReason" => nil, "description" => "Indicates this type is a union. `possibleTypes` is a valid field.", "isDeprecated" => nil, "name" => "UNION"}],
          "fields" => nil, "inputFields" => nil, "interfaces" => nil, "kind" => "ENUM", "name" => "__TypeKind", "possibleTypes" => nil}]}
-      }
+    })
   end
 end


### PR DESCRIPTION
The assert_execute permutations were getting out of hand. This has now
bean alleviated by making use of the keyword parameters of
GraphQL.execute.
