### PR TITLE
Include Input types in response to introspection query.

### DIFF
--- a/test/graphql/type/introspection_test.exs
+++ b/test/graphql/type/introspection_test.exs
@@ -4,6 +4,9 @@ defmodule GraphQL.Type.IntrospectionTest do
   import ExUnit.TestHelpers
 
   alias GraphQL.Schema
+  alias GraphQL.Type.Input
+  alias GraphQL.Type.Int
+  alias GraphQL.Type.NonNull
   alias GraphQL.Type.ObjectType
   alias GraphQL.Type.String
 
@@ -18,6 +21,71 @@ defmodule GraphQL.Type.IntrospectionTest do
         }
       })
     end
+  end
+
+  test "include input types in response to introspection query" do
+    type = %ObjectType{
+      name: "Thing",
+      description: "Things",
+      fields: %{
+        id: %{type: %Int{}},
+        name: %{type: %String{}},
+      },
+    }
+
+    thing_input_type = %Input{
+      name: "ThingInput",
+      fields: %{
+        name: %{type: %String{}},
+      }
+    }
+
+    output_type = %ObjectType{
+      name: "SaveThingPayload",
+      fields: %{
+        thing: %{
+          type: type,
+          resolve: fn(payload, _, _) ->
+            payload
+          end
+        },
+      },
+    }
+
+    input_type = %Input{
+      name: "SaveThingInput",
+      fields: %{
+        id: %{type: %NonNull{ofType: %Int{}}},
+        params: %{type: %NonNull{ofType: thing_input_type}},
+      }
+    }
+
+    schema = %Schema{
+      query: %ObjectType{
+        name: "QueryRoot",
+        fields: %{onlyField: %{type: %String{}}}
+      },
+      mutation: %ObjectType{
+        name: "Mutation",
+        description: "Root object for performing data mutations",
+        fields: %{
+          save_thing: %{
+            type: output_type,
+            args: %{
+              input: %{
+                type: %NonNull{ofType: input_type}
+              }
+            },
+            resolve: fn(data, args, info) ->
+              data
+            end
+          }
+        }
+      }
+    }
+
+    {:ok, result} = execute(schema, GraphQL.Type.Introspection.query)
+    assert Enum.find(result.data["__schema"]["types"], fn(type) -> type["name"] == "ThingInput" end)
   end
 
   test "exposes descriptions on types and fields" do


### PR DESCRIPTION
Why:
- Previously, the response to the full introspection query did not include Input types in its types list if they were arguments to an Input type. This became clear while working on graphql_relay as Relay relies on the result of the full introspection query which wasn't including all input types.

This change addresses the need by:
- While reducing types we needed a pattern match for %Input{} types to reduce their arguments.
