### PR TITLE
WIP: batch resolution

### DIFF
--- a/lib/graphql/execution/batch_resolvable.ex
+++ b/lib/graphql/execution/batch_resolvable.ex
@@ -1,0 +1,49 @@
+
+defprotocol GraphQL.Execution.BatchResolvable do
+  @fallback_to_any true
+
+  def group_key(batch_resolvable)
+
+  def batch(batch_resolvable1, batch_resolvable2)
+
+  def resolve(batch_resolvable)
+
+  def batchable?(batch_resolvable)
+end
+
+defimpl GraphQL.Execution.BatchResolvable, for: Any do
+  def group_key(batch_resolvable) do
+    raise "BatchResolvable.group_key/1 not supported for type Any"
+  end
+
+  def batch(batch_resolvable1, batch_resolvable2) do
+    raise "BatchResolvable.batch/2 not supported for type Any"
+  end
+
+  def resolve(batch_resolvable) do
+    raise "BatchResolvable.resolve/1 not supported for type Any"
+  end
+
+  def batchable?(batch_resolvable), do: false
+end
+
+defmodule GraphQL.Execution.BatchResolvable.Group do
+  alias GraphQL.Execution.BatchResolvable
+
+  def partition(batch_resolvables) do
+    Enum.reduce(batch_resolvables, %{}, fn(batch_resolvable, batches) ->
+      combine_into_batch(batches, batch_resolvable)
+    end) |> Map.values()
+  end
+
+  defp combine_into_batch(batches, batch_resolvable) do
+    batch_key = BatchResolvable.group_key(batch_resolvable)
+    if Map.has_key?(batches, batch_key) do
+      %{batches | batch_key => BatchResolvable.batch(batches[batch_key], batch_resolvable)}
+    else
+      Map.merge(batches, %{batch_key => batch_resolvable})
+    end
+  end
+end
+
+

--- a/lib/graphql/execution/execution_context.ex
+++ b/lib/graphql/execution/execution_context.ex
@@ -1,14 +1,14 @@
 
 defmodule GraphQL.Execution.ExecutionContext do
 
-  defstruct [:schema, :fragments, :root_value, :operation, :variable_values, :errors]
+  defstruct [:schema, :fragments, :root_value, :operation, :variable_values, :errors, :batch_resolvables]
   @type t :: %__MODULE__{
     schema: GraphQL.Schema.t,
     fragments: struct,
     root_value: Map,
     operation: Map,
     variable_values: Map,
-    errors: list(GraphQL.Error.t)
+    batch_resolvables: list
   }
 
   @spec new(GraphQL.Schema.t, GraphQL.Document.t, map, map, String.t) :: __MODULE__.t
@@ -19,6 +19,7 @@ defmodule GraphQL.Execution.ExecutionContext do
       root_value: root_value,
       operation: nil,
       variable_values: variable_values || %{},
+      batch_resolvables: [],
       errors: []
     }, fn(definition, context) ->
 
@@ -41,5 +42,9 @@ defmodule GraphQL.Execution.ExecutionContext do
   @spec report_error(__MODULE__.t, String.t) :: __MODULE__.t
   def report_error(context, msg) do
     put_in(context.errors, [%{"message" => msg} | context.errors])
+  end
+
+  def add_batch_resolvable(context, batch_resolvable) do
+    put_in(context.batch_resolvables, [batch_resolvable | context.batch_resolvables])
   end
 end

--- a/lib/graphql/execution/patch.ex
+++ b/lib/graphql/execution/patch.ex
@@ -1,0 +1,12 @@
+
+# A Patch represents an update to the result tree.
+# It is used during batch resolution in order to update potentially multiple
+# nodes in the tree with the result of execution of a BatchResolvable.
+defmodule GraphQL.Execution.Patch do
+  defstruct [:path, :value]
+
+  def apply(results, patch) do
+    put_in(results, patch.path, patch.value)
+  end
+end
+

--- a/test/graphql/execution/batch_resolution_test.exs
+++ b/test/graphql/execution/batch_resolution_test.exs
@@ -1,0 +1,91 @@
+
+defmodule GraphQL.Execution.Executor.BatchResolutionTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.TestHelpers
+
+  alias GraphQL.Schema
+  alias GraphQL.Type.ObjectType
+  alias GraphQL.Type.String
+  alias GraphQL.Type.Int
+  alias GraphQL.Execution.Resolvable
+  alias GraphQL.Execution.BatchResolvable
+  alias GraphQL.Execution.BatchResult
+  alias GraphQL.Execution.Patch
+
+  defmodule TestSchema do
+
+    defmodule UsersByIdResolver do
+      defstruct id_to_path: %{}
+
+      defimpl Resolvable do
+        def resolve(_resolvable, _source, %{id: id}, info) do
+          # TODO how do we get the path?
+          {:ok, %UsersByIdResolver{id_to_path: %{id => info.path}}}
+        end
+      end
+
+      defimpl BatchResolvable do
+        def group_key(_), do: "users_by_id"
+
+        def batch(b1, b2) do
+          %UsersByIdResolver{id_to_path: Map.merge(b1.id_to_path, b2.id_to_path)}
+        end
+
+        def resolve(resolver) do
+          resolver.id_to_path |> Enum.map(fn({user_id, path}) ->
+            %Patch{path: path, value: TestSchema.User.data[user_id]}
+          end)
+        end
+
+        def batchable?(_), do: true
+      end
+    end
+
+    defmodule User do
+
+      def data, do: %{0 => %{name: "James"}, 1 => %{name: "Josh"}}
+
+      def type do
+        %ObjectType{
+          name: "User",
+          fields: %{
+            id: %{type: %Int{}},
+            name: %{type: %String{}}
+          }
+        }
+      end
+    end
+
+    def schema do
+      %Schema{
+        query: %ObjectType{
+          name: "Query",
+          fields: %{
+            user: %{
+              type: User,
+              args: %{
+                id: %{type: %Int{}}
+              },
+              resolve: %UsersByIdResolver{}
+            }
+          }
+        }
+      }
+    end
+  end
+
+  test "basic query execution" do
+    {:ok, result} = execute(TestSchema.schema, """
+    {
+      user_0: user(id: 0) { name }
+      user_1: user(id: 1) { name }
+    }
+    """)
+    assert_data(result, %{
+      user_0: %{name: "James"},
+      user_1: %{name: "Josh"}
+    })
+  end
+
+end


### PR DESCRIPTION
_NOT READY FOR MERGE_

The purpose of batch resolvers is to avoid the N+1 problem.

The tests don't pass yet. We need to be able to capture the 'path' through the result tree during execution in order for the `Patch` mechanism to work when async resolved batch responses are received. This patch could just be a `Stack` object or an array threaded through the execution process or we could leverage `TypeInfo` from the validations pipeline.
