### PR TITLE
Nit: Fix typo in doc block

### DIFF
--- a/lib/graphql/type/introspection.ex
+++ b/lib/graphql/type/introspection.ex
@@ -50,7 +50,7 @@ defmodule GraphQL.Type.Introspection do
             resolve: fn(%{mutation: mutation}) -> mutation end
           },
           subscriptionType: %{
-            description: "If this server support subscription, the type that subscription operations will be rooted at.",
+            description: "If this server supports subscription, the type that subscription operations will be rooted at.",
             type: Type,
             resolve: nil #fn(%{subscription: subscription}, _, _,_) -> subscription end
           },

--- a/lib/mix/tasks/compile.graphql.ex
+++ b/lib/mix/tasks/compile.graphql.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Compile.Graphql do
 
   Currently only handles schema files, but will support queries in future.
 
-  To use this you need to add the `:graphql` compiler to the front ofyour compiler chain.
+  To use this you need to add the `:graphql` compiler to the front of your compiler chain.
   This just needs to be anywhere before the Elixir compiler because we are
   generating Elixir code.
 


### PR DESCRIPTION
Small nit: noticed a missing space while reading through the source.