### PR TITLE
Update readme to suggest to use 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ First, add GraphQL to your `mix.exs` dependencies:
 
 ```elixir
 defp deps do
-  [{:graphql, "~> 0.3"}]
+  [{:graphql, "~> 0.3.2"}]
 end
 ```
 


### PR DESCRIPTION
When first trying this lib in elixir I was faced with deprecation errors this PR suggest the latest release and hopefully helps new users to have a smoother first experience:

Example error:
```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
```